### PR TITLE
Handle group status and setu disable states

### DIFF
--- a/handlers/command_handlers/setu_handler.py
+++ b/handlers/command_handlers/setu_handler.py
@@ -1,15 +1,18 @@
-from telegram import Update
-from telegram.ext import CommandHandler
+from io import BytesIO
 
-from defines import UserStatus, GroupStatus
+from telegram import Update
+from telegram.ext import CommandHandler, ContextTypes
+
+from defines import GroupStatus, UserStatus
 from exps import UserBlockedError, GroupBlockedError
 
 from utils import is_group_type
 
 from registries import user_registry, group_registry
+from services.image_service import get_image
 
 
-async def setu(update: Update, context) -> None:
+async def setu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     user = await user_registry.get_user_by_id(update.effective_user.id)
     if user.status == UserStatus.BLOCKED:
         raise UserBlockedError("您已被禁止使用本Bot")
@@ -17,10 +20,50 @@ async def setu(update: Update, context) -> None:
         raise UserBlockedError("您未启用本Bot, 请先到设置中启用。")
     chat_id = update.effective_chat.id
     is_group = is_group_type(update.effective_chat.type)
+    group = None
     if is_group:
         group = await group_registry.get_group_by_id(chat_id)
         if group.status == GroupStatus.BLOCKED:
             raise GroupBlockedError("本群组已被禁止使用本Bot")
+        if not group.enable or group.status == GroupStatus.DISABLED:
+            raise GroupBlockedError("本群组暂未启用本Bot")
+        if not group.allow_setu:
+            raise GroupBlockedError("本群组已关闭涩图功能")
+
+    sanity_limit = user.sanity_limit
+    allow_r18g = user.allow_r18g
+    if is_group and group is not None:
+        sanity_limit = min(sanity_limit, group.sanity_limit)
+        allow_r18g = allow_r18g and group.allow_r18g
+
+    illust, image_bytes, page_id, filename = await get_image(
+        sanity_limit=sanity_limit,
+        allow_r18g=allow_r18g,
+    )
+
+    image_file = BytesIO(image_bytes)
+    image_file.name = filename
+
+    caption_lines = [
+        f"标题: {illust.title}",
+        f"作者: {illust.author_name} (Pixiv {illust.author_id})",
+        f"页码: {page_id + 1}/{illust.page_count}",
+        f"AI 作品: {'是' if illust.is_ai else '否'}",
+    ]
+
+    origin_urls = illust.origin_urls or []
+    if isinstance(origin_urls, list):
+        if page_id < len(origin_urls) and origin_urls[page_id]:
+            caption_lines.append(f"原图: {origin_urls[page_id]}")
+    elif isinstance(origin_urls, str) and origin_urls:
+        caption_lines.append(f"原图: {origin_urls}")
+
+    await context.bot.send_photo(
+        chat_id=chat_id,
+        photo=image_file,
+        caption="\n".join(caption_lines),
+        reply_to_message_id=update.effective_message.id,
+    )
 
 
 setu_handler = CommandHandler("setu", setu)

--- a/models/groups.py
+++ b/models/groups.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, Boolean, Enum, JSON
 
-from defines import GroupChatMode
+from defines import GroupChatMode, GroupStatus
 from configs import config as file_config
 
 from .base import Base
@@ -9,6 +9,7 @@ from .base import Base
 class Group(Base):
     __tablename__ = f"{file_config.db_prefix}groups"
     id = Column(Integer, primary_key=True, comment='群组的 ID')
+    status = Column(Enum(GroupStatus), default=GroupStatus.ENABLED, nullable=False, comment='群组状态')
     enable = Column(Boolean, default=True, nullable=False, comment='是否启用此群组')
     name = Column(String(64), nullable=True, comment='群组的名称')
     enable_chat = Column(Boolean, default=False, nullable=False, comment='是否启用 AI 聊天')

--- a/registries/group_registry.py
+++ b/registries/group_registry.py
@@ -1,10 +1,7 @@
-import random
-
-from sqlalchemy import select, update, func
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models import Illustration, Group
-from defines import GroupStatus
+from models import Group
 
 from .engine import engine
 
@@ -19,9 +16,9 @@ async def add_group(group: Group) -> None:
 async def get_group_by_id(group_id: int) -> Group:
     async with engine.new_session() as session:
         session: AsyncSession = session
-        result = await session.execute(select(GroupStatus).where(Group.id == group_id))
-        group = result.scalar()
-        if result is None:
+        result = await session.execute(select(Group).where(Group.id == group_id))
+        group = result.scalars().first()
+        if group is None:
             new_group = Group(id=group_id)
             await add_group(new_group)
             return await get_group_by_id(group_id)

--- a/registries/illust_registry.py
+++ b/registries/illust_registry.py
@@ -1,10 +1,9 @@
 import random
 
-from sqlalchemy import select, update, func
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models import Illustration
-from defines import UserStatus
 
 from .engine import engine
 
@@ -12,21 +11,32 @@ from .engine import engine
 async def get_illust_info(pixiv_id: int) -> Illustration | None:
     async with engine.new_session() as session:
         session: AsyncSession = session
-        result = await session.execute(select(Illustration).where(Illustration.id == pixiv_id))
-        return result.scalar().first()
+        result = await session.execute(
+            select(Illustration).where(Illustration.id == pixiv_id)
+        )
+        return result.scalars().first()
 
 
 async def random_illust(sanity_limit: int = 5, r18g: bool = False):
     async with engine.new_session() as session:
         session: AsyncSession = session
-        row_count: int | None = (await session.execute(select(func.count(Illustration.id)))).scalars().first()
-        if row_count is None or row_count == 0:
+
+        count_stmt = select(func.count(Illustration.id))
+        if not r18g:
+            count_stmt = count_stmt.where(Illustration.r18g.is_(False))
+        count_stmt = count_stmt.where(Illustration.sanity_level <= sanity_limit)
+
+        row_count = (await session.execute(count_stmt)).scalar_one()
+        if row_count == 0:
             return None
-        random_offset = random.randint(0, row_count - 1)
+
+        random_offset = random.randrange(row_count)
+
         stmt = select(Illustration)
         if not r18g:
-            stmt = stmt.where(Illustration.r18g == False)
+            stmt = stmt.where(Illustration.r18g.is_(False))
         stmt = stmt.where(Illustration.sanity_level <= sanity_limit)
         stmt = stmt.offset(random_offset).limit(1)
+
         result = await session.execute(stmt)
-        return result.scalar().first()
+        return result.scalars().first()

--- a/services/file_service/download_file.py
+++ b/services/file_service/download_file.py
@@ -28,7 +28,7 @@ async def download_file(filename: str, url: str, replace: bool = False):
                         async with session.get(url) as response:
                             if response.status == 200:
                                 # 打开文件准备写入
-                                with aiofiles.open(file_url, 'wb') as f:
+                                async with aiofiles.open(file_url, 'wb') as f:
                                     await f.write(await response.content.read())
                                 return
                             else:

--- a/services/image_service/__init__.py
+++ b/services/image_service/__init__.py
@@ -1,0 +1,3 @@
+from .get_image import get_image
+
+__all__ = ["get_image"]

--- a/services/image_service/get_image.py
+++ b/services/image_service/get_image.py
@@ -1,3 +1,6 @@
+import os
+import random
+
 from models import Illustration
 
 import registries
@@ -5,24 +8,97 @@ from services import file_service
 from exps import BadRequestError
 
 
-async def get_image(pixiv_id: int = None, page_id: int = None, origin: bool = False) -> tuple[Illustration, bytes]:
+def _resolve_page_id(illust: Illustration, page_id: int | None, allow_random: bool) -> int:
+    if illust.page_count is None or illust.page_count <= 0:
+        raise FileNotFoundError("该作品没有可用的图片页")
+    if page_id is None:
+        if allow_random:
+            return random.randrange(illust.page_count)
+        return 0
+    if page_id < 0 or page_id >= illust.page_count:
+        raise BadRequestError("请求的页码超出范围")
+    return page_id
+
+
+def _resolve_link(illust: Illustration, page_id: int) -> str:
+    file_urls = illust.file_urls or []
+    origin_urls = illust.origin_urls or []
+
+    if isinstance(file_urls, list):
+        if page_id < len(file_urls) and file_urls[page_id]:
+            return file_urls[page_id]
+    elif isinstance(file_urls, str) and file_urls:
+        return file_urls
+
+    if isinstance(origin_urls, list):
+        if page_id < len(origin_urls) and origin_urls[page_id]:
+            return origin_urls[page_id]
+    elif isinstance(origin_urls, str) and origin_urls:
+        return origin_urls
+
+    raise FileNotFoundError("没有找到对应页面的图片链接")
+
+
+def _resolve_extension(illust: Illustration, page_id: int, link: str) -> str:
+    file_ext = illust.file_ext
+    ext: str | None = None
+
+    if isinstance(file_ext, list):
+        if page_id < len(file_ext):
+            candidate = file_ext[page_id]
+            if isinstance(candidate, str):
+                ext = candidate
+    elif isinstance(file_ext, tuple):
+        if len(file_ext) > 1 and isinstance(file_ext[1], str):
+            ext = file_ext[1]
+    elif isinstance(file_ext, str):
+        ext = file_ext
+
+    if not ext:
+        ext = os.path.splitext(link)[1]
+
+    if not ext:
+        ext = ".jpg"
+    elif not ext.startswith("."):
+        ext = f".{ext}"
+
+    return ext
+
+
+async def get_image(
+    pixiv_id: int | None = None,
+    page_id: int | None = None,
+    origin: bool = False,
+    sanity_limit: int = 5,
+    allow_r18g: bool = False,
+) -> tuple[Illustration, bytes, int, str]:
     if pixiv_id is not None:
         illust = await registries.get_illust_info(pixiv_id)
         if illust is None:
-            raise FileNotFoundError(f'No such illust in database: {pixiv_id}')
-        link = illust.file_urls[page_id]
-        if origin:
-            image = await file_service.get_file(
-                filename=f"{pixiv_id}_{page_id}.{illust.file_ext}",
-                url=link
-            )
-            return illust, image
-        else:
-            image = await file_service.get_image(
-                filename=f"{pixiv_id}_{page_id}.{illust.file_ext}",
-                url=link
-            )
-            return illust, image
+            raise FileNotFoundError(f"No such illust in database: {pixiv_id}")
+        resolved_page_id = _resolve_page_id(illust, page_id, allow_random=False)
+        link = _resolve_link(illust, resolved_page_id)
+        ext = _resolve_extension(illust, resolved_page_id, link)
+        filename = f"{illust.id}_{resolved_page_id}{ext}"
+        fetcher = file_service.get_file if origin else file_service.get_image
+        image = await fetcher(filename=filename, url=link)
+        if image is None:
+            raise FileNotFoundError("未能获取到图片文件")
+        return illust, image, resolved_page_id, filename
+
     if origin:
         raise BadRequestError("随机图片不可请求原图")
-    illust = await registries.random_illust()
+
+    illust = await registries.random_illust(sanity_limit=sanity_limit, r18g=allow_r18g)
+    if illust is None:
+        raise FileNotFoundError("数据库中没有符合条件的插画")
+
+    resolved_page_id = _resolve_page_id(illust, page_id, allow_random=True)
+    link = _resolve_link(illust, resolved_page_id)
+    ext = _resolve_extension(illust, resolved_page_id, link)
+    filename = f"{illust.id}_{resolved_page_id}{ext}"
+    image = await file_service.get_image(filename=filename, url=link)
+    if image is None:
+        raise FileNotFoundError("未能获取到图片文件")
+
+    return illust, image, resolved_page_id, filename


### PR DESCRIPTION
## Summary
- fix group and illustration registries so lookups return the expected ORM objects and respect filtering when selecting random artwork
- harden the image service by resolving page IDs, URLs and extensions, exposing it for reuse, and correcting asynchronous downloads
- update the /setu command to honour user and group preferences, fetch an illustration, and deliver it to Telegram with relevant caption details
- ensure the /setu command differentiates blocked groups, disabled bots, and groups with setu disabled by adding an ORM status field and specific error messages

## Testing
- python -m compileall handlers/command_handlers/setu_handler.py models/groups.py


------
https://chatgpt.com/codex/tasks/task_e_68da1fa5a308832f97de71ab110f0d3b