### PR TITLE
Handle missing Pixiv token configuration

### DIFF
--- a/handlers/command_handlers/p_info_handler.py
+++ b/handlers/command_handlers/p_info_handler.py
@@ -5,6 +5,12 @@ from services import pixiv
 
 
 async def p_info_func(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not pixiv.enabled:
+        await update.message.reply_text(
+            text="Pixiv 功能未启用，请联系管理员配置令牌。",
+            reply_to_message_id=update.message.message_id,
+        )
+        return
     pixiv_id = context.args[0]
     illust = await pixiv.get_illust_info_by_pixiv_id(pixiv_id)
     await update.message.reply_markdown(

--- a/main.py
+++ b/main.py
@@ -44,7 +44,10 @@ async def lifespan(app: FastAPI):
         await storage.get_config()
     await tg_bot.config()
     await pixiv.read_token_from_config()
-    pixiv.token_refresh()
+    if pixiv.enabled:
+        pixiv.token_refresh()
+    else:
+        logger.warning("Pixiv features disabled due to missing token")
 
     # 新增：初始化数据库配置
     try:


### PR DESCRIPTION
## Summary
- disable Pixiv functionality when no refresh token is configured and log warnings instead of raising
- skip Pixiv token refresh during startup if the feature is disabled
- inform users of the /pinfo command when Pixiv features are unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbe29334b8832fbbdbfc2974a2bcff