### PR TITLE
Rebuild PrimeVue admin console with component architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# ACG 图像 Bot 管理端
+
+该项目提供 FastAPI 后端与基于 PrimeVue 的管理控制台。要在本地运行完整的控制台体验，请按以下步骤操作：
+
+1. 安装 Python 依赖并启动 FastAPI 后端：
+   ```bash
+   uvicorn main:app --reload
+   ```
+2. 安装前端依赖并启动开发服务器：
+   ```bash
+   cd webui
+   npm install
+   npm run dev
+   ```
+   开发服务器默认运行在 `http://localhost:5173/admin/`，已通过 Vite 代理自动代理到 FastAPI 的 `/api` 路由。
+3. 构建生产前端时执行：
+   ```bash
+   npm run build
+   ```
+   构建后的静态文件位于 `webui/dist`，FastAPI 会自动检测并通过 `/admin` 提供服务。
+
+后端已实现仪表盘、群组管理、私聊管理以及全局功能开关等 RESTful API，前端控制台通过这些接口实现实时管理能力，并预留了未来功能扩展位置。

--- a/routers/__init__.py
+++ b/routers/__init__.py
@@ -1,0 +1,10 @@
+"""FastAPI router registrations for the administrative API."""
+
+from . import dashboard, groups, private, configs
+
+__all__ = [
+    "dashboard",
+    "groups",
+    "private",
+    "configs",
+]

--- a/routers/configs.py
+++ b/routers/configs.py
@@ -1,0 +1,147 @@
+"""Configuration endpoints exposing feature toggles for the admin console."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+from registries import config_registry
+
+router = APIRouter(prefix="/api/config", tags=["config"])
+
+
+class FeatureFlag(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    key: str
+    label: str
+    description: str
+    value: bool | None
+    editable: bool
+    category: str
+
+
+class FeatureFlagUpdate(BaseModel):
+    value: bool
+
+
+class FeatureFlagResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    features: list[FeatureFlag]
+    placeholders: list[FeatureFlag]
+
+
+async def _get_bool_config(key: str, default: bool | None = None) -> bool | None:
+    value = await config_registry.get_config(key)
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.lower()
+        if lowered in {"true", "1", "yes", "y", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "n", "off"}:
+            return False
+    return default
+
+
+@router.get("/features", response_model=FeatureFlagResponse)
+async def get_feature_flags() -> FeatureFlagResponse:
+    """Return active feature flags and placeholder configuration entries."""
+
+    feature_definitions: list[dict[str, Any]] = [
+        {
+            "key": "allow_r18g",
+            "label": "允许 R18G",
+            "description": "控制全局是否允许在内容推荐中出现 R18G 资源。",
+            "default": False,
+            "category": "内容安全",
+            "editable": True,
+        },
+        {
+            "key": "enable_on_new_group",
+            "label": "新群自动启用",
+            "description": "当新的群组加入时是否默认启用全部功能。",
+            "default": False,
+            "category": "群组管理",
+            "editable": True,
+        },
+    ]
+
+    features: list[FeatureFlag] = []
+    for definition in feature_definitions:
+        value = await _get_bool_config(definition["key"], definition["default"])
+        features.append(
+            FeatureFlag(
+                key=definition["key"],
+                label=definition["label"],
+                description=definition["description"],
+                value=value,
+                editable=definition["editable"],
+                category=definition["category"],
+            )
+        )
+
+    placeholders: list[FeatureFlag] = [
+        FeatureFlag(
+            key="setu_moderation",
+            label="涩图内容控制",
+            description="已在群组配置中细化管理，这里预留用于未来的全局策略。",
+            value=None,
+            editable=False,
+            category="内容安全",
+        ),
+        FeatureFlag(
+            key="content_moderation_pipeline",
+            label="智能审核",
+            description="计划接入第三方审核服务，用于自动拦截违规内容。",
+            value=None,
+            editable=False,
+            category="实验功能",
+        ),
+        FeatureFlag(
+            key="analytics_stream",
+            label="实时统计",
+            description="用于展示实时消息趋势的功能占位。",
+            value=None,
+            editable=False,
+            category="数据洞察",
+        ),
+    ]
+
+    return FeatureFlagResponse(features=features, placeholders=placeholders)
+
+
+@router.put("/features/{key}", response_model=FeatureFlag)
+async def update_feature_flag(key: str, payload: FeatureFlagUpdate) -> FeatureFlag:
+    """Update a mutable feature flag value."""
+
+    mutable_keys = {"allow_r18g", "enable_on_new_group"}
+    if key not in mutable_keys:
+        raise HTTPException(status_code=404, detail="Feature flag not found or not editable")
+
+    await config_registry.update_config(key, payload.value)
+
+    value = await _get_bool_config(key, payload.value)
+    labels = {
+        "allow_r18g": ("允许 R18G", "控制全局是否允许在内容推荐中出现 R18G 资源。", "内容安全"),
+        "enable_on_new_group": (
+            "新群自动启用",
+            "当新的群组加入时是否默认启用全部功能。",
+            "群组管理",
+        ),
+    }
+    label, description, category = labels[key]
+
+    return FeatureFlag(
+        key=key,
+        label=label,
+        description=description,
+        value=value,
+        editable=True,
+        category=category,
+    )

--- a/routers/dashboard.py
+++ b/routers/dashboard.py
@@ -1,0 +1,142 @@
+"""Dashboard endpoints providing summarized analytics for the Web UI."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import func, select, desc
+
+from models import Group, GroupChatHistory, PrivateChatHistory, User
+from registries.engine import engine
+
+router = APIRouter(prefix="/api/dashboard", tags=["dashboard"])
+
+
+class ActivityEntry(BaseModel):
+    """Represents a recent activity item from group or private messages."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    message_id: int
+    scope: str
+    scope_id: int
+    preview: str | None
+    sent_at: datetime | None
+
+
+class DashboardSummary(BaseModel):
+    """Top-level metrics consumed by the dashboard UI."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    total_groups: int
+    active_groups: int
+    chat_enabled_groups: int
+    total_users: int
+    chat_enabled_users: int
+    total_group_messages: int
+    total_private_messages: int
+    recent_activity: list[ActivityEntry]
+
+
+@router.get("/summary", response_model=DashboardSummary)
+async def get_dashboard_summary(limit: int = 10) -> DashboardSummary:
+    """Return summarized metrics and latest activity for the dashboard view."""
+
+    async with engine.new_session() as session:
+        total_groups = (await session.execute(select(func.count(Group.id)))).scalar_one()
+        active_groups = (
+            await session.execute(select(func.count(Group.id)).where(Group.enable.is_(True)))
+        ).scalar_one()
+        chat_enabled_groups = (
+            await session.execute(
+                select(func.count(Group.id)).where(Group.enable_chat.is_(True))
+            )
+        ).scalar_one()
+
+        total_users = (await session.execute(select(func.count(User.id)))).scalar_one()
+        chat_enabled_users = (
+            await session.execute(select(func.count(User.id)).where(User.enable_chat.is_(True)))
+        ).scalar_one()
+
+        total_group_messages = (
+            await session.execute(select(func.count(GroupChatHistory.message_id)))
+        ).scalar_one()
+        total_private_messages = (
+            await session.execute(select(func.count(PrivateChatHistory.message_id)))
+        ).scalar_one()
+
+        group_messages = (
+            await session.execute(
+                select(
+                    GroupChatHistory.message_id,
+                    GroupChatHistory.group_id,
+                    GroupChatHistory.text,
+                    GroupChatHistory.sent_at,
+                    GroupChatHistory.bot_send,
+                )
+                .order_by(desc(GroupChatHistory.sent_at))
+                .limit(limit)
+            )
+        ).all()
+
+        private_messages = (
+            await session.execute(
+                select(
+                    PrivateChatHistory.message_id,
+                    PrivateChatHistory.user_id,
+                    PrivateChatHistory.text,
+                    PrivateChatHistory.sent_at,
+                    PrivateChatHistory.bot_send,
+                )
+                .order_by(desc(PrivateChatHistory.sent_at))
+                .limit(limit)
+            )
+        ).all()
+
+    def _preview(text: str | None) -> str | None:
+        if not text:
+            return None
+        text = text.strip()
+        if len(text) > 120:
+            return f"{text[:117]}..."
+        return text
+
+    activities: list[ActivityEntry] = []
+    for msg in group_messages:
+        activities.append(
+            ActivityEntry(
+                message_id=msg.message_id,
+                scope="group_bot" if msg.bot_send else "group",
+                scope_id=msg.group_id,
+                preview=_preview(msg.text),
+                sent_at=msg.sent_at,
+            )
+        )
+
+    for msg in private_messages:
+        activities.append(
+            ActivityEntry(
+                message_id=msg.message_id,
+                scope="private_bot" if msg.bot_send else "private",
+                scope_id=msg.user_id,
+                preview=_preview(msg.text),
+                sent_at=msg.sent_at,
+            )
+        )
+
+    activities.sort(key=lambda item: item.sent_at or datetime.min, reverse=True)
+    activities = activities[:limit]
+
+    return DashboardSummary(
+        total_groups=total_groups,
+        active_groups=active_groups,
+        chat_enabled_groups=chat_enabled_groups,
+        total_users=total_users,
+        chat_enabled_users=chat_enabled_users,
+        total_group_messages=total_group_messages,
+        total_private_messages=total_private_messages,
+        recent_activity=activities,
+    )

--- a/routers/groups.py
+++ b/routers/groups.py
@@ -1,0 +1,312 @@
+"""Group management endpoints for administrative operations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import String, cast, desc, func, or_, select
+
+from defines import GroupChatMode, GroupStatus
+from models import Group, GroupChatHistory
+from registries.engine import engine
+
+router = APIRouter(prefix="/api/groups", tags=["groups"])
+
+
+class EnumOption(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
+    label: str
+    value: str
+
+
+class ChatMessage(BaseModel):
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
+
+    message_id: int
+    user_id: int
+    type: str
+    bot_send: bool
+    text: str | None
+    sent_at: datetime | None
+
+
+class GroupBase(BaseModel):
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
+
+    id: int
+    name: str | None
+    status: GroupStatus
+    enable: bool
+    enable_chat: bool
+    chat_mode: GroupChatMode
+    sanity_limit: int
+    allow_r18g: bool
+    allow_setu: bool
+    admin_ids: list[int]
+
+
+class GroupListItem(GroupBase):
+    message_count: int
+    last_activity: datetime | None
+
+
+class GroupListResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    total: int
+    items: list[GroupListItem]
+
+
+class GroupDetail(GroupListItem):
+    recent_messages: list[ChatMessage]
+
+
+class GroupUpdate(BaseModel):
+    """Payload accepted to update a group's configurable options."""
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    name: str | None = None
+    enable: bool | None = None
+    enable_chat: bool | None = None
+    chat_mode: GroupChatMode | None = Field(default=None)
+    sanity_limit: int | None = Field(default=None, ge=0)
+    allow_r18g: bool | None = None
+    allow_setu: bool | None = None
+    admin_ids: list[int] | None = None
+
+
+def _apply_filters(stmt, *, search: str | None, enable: bool | None, chat_enabled: bool | None):
+    if search:
+        like_term = f"%{search}%"
+        stmt = stmt.where(
+            or_(
+                Group.name.ilike(like_term),
+                cast(Group.id, String).ilike(like_term),
+            )
+        )
+    if enable is not None:
+        stmt = stmt.where(Group.enable.is_(enable))
+    if chat_enabled is not None:
+        stmt = stmt.where(Group.enable_chat.is_(chat_enabled))
+    return stmt
+
+
+@router.get("/meta", response_model=dict)
+async def get_group_meta() -> dict[str, Any]:
+    """Return enum metadata required by the management console."""
+
+    return {
+        "chat_modes": [
+            EnumOption(label=mode.name.title(), value=mode.value) for mode in GroupChatMode
+        ],
+        "statuses": [
+            EnumOption(label=status.name.title(), value=status.value) for status in GroupStatus
+        ],
+    }
+
+
+@router.get("", response_model=GroupListResponse)
+async def list_groups(
+    q: str | None = Query(default=None, description="Search by group id or name"),
+    enable: bool | None = Query(default=None, description="Filter by enabled flag"),
+    chat_enabled: bool | None = Query(
+        default=None, description="Filter by AI chat enabled flag"
+    ),
+    limit: int = Query(default=25, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> GroupListResponse:
+    """List groups with aggregated metadata for the administrative UI."""
+
+    async with engine.new_session() as session:
+        stmt = (
+            select(
+                Group,
+                func.count(GroupChatHistory.message_id).label("message_count"),
+                func.max(GroupChatHistory.sent_at).label("last_activity"),
+            )
+            .outerjoin(GroupChatHistory, GroupChatHistory.group_id == Group.id)
+            .group_by(Group.id)
+        )
+
+        stmt = _apply_filters(stmt, search=q, enable=enable, chat_enabled=chat_enabled)
+        stmt = stmt.order_by(Group.id).limit(limit).offset(offset)
+        result = await session.execute(stmt)
+        rows = result.all()
+
+        count_stmt = select(func.count()).select_from(Group)
+        count_stmt = _apply_filters(count_stmt, search=q, enable=enable, chat_enabled=chat_enabled)
+        total = (await session.execute(count_stmt)).scalar_one()
+
+    items = [
+        GroupListItem(
+            id=row.Group.id,
+            name=row.Group.name,
+            status=row.Group.status,
+            enable=row.Group.enable,
+            enable_chat=row.Group.enable_chat,
+            chat_mode=row.Group.chat_mode,
+            sanity_limit=row.Group.sanity_limit,
+            allow_r18g=row.Group.allow_r18g,
+            allow_setu=row.Group.allow_setu,
+            admin_ids=row.Group.admin_ids or [],
+            message_count=row.message_count or 0,
+            last_activity=row.last_activity,
+        )
+        for row in rows
+    ]
+
+    return GroupListResponse(total=total, items=items)
+
+
+@router.get("/{group_id}", response_model=GroupDetail)
+async def get_group_detail(group_id: int, recent_limit: int = Query(default=20, ge=1, le=50)) -> GroupDetail:
+    """Retrieve detailed configuration and recent history for a group."""
+
+    async with engine.new_session() as session:
+        group = await session.get(Group, group_id)
+        if group is None:
+            raise HTTPException(status_code=404, detail="Group not found")
+
+        stats = (
+            await session.execute(
+                select(
+                    func.count(GroupChatHistory.message_id),
+                    func.max(GroupChatHistory.sent_at),
+                ).where(GroupChatHistory.group_id == group_id)
+            )
+        ).one()
+        message_count, last_activity = stats
+
+        recent = (
+            await session.execute(
+                select(GroupChatHistory)
+                .where(GroupChatHistory.group_id == group_id)
+                .order_by(desc(GroupChatHistory.sent_at))
+                .limit(recent_limit)
+            )
+        ).scalars().all()
+
+    recent_messages = [
+        ChatMessage(
+            message_id=msg.message_id,
+            user_id=msg.user_id,
+            type=msg.type.value,
+            bot_send=msg.bot_send,
+            text=msg.text,
+            sent_at=msg.sent_at,
+        )
+        for msg in recent
+    ]
+
+    return GroupDetail(
+        id=group.id,
+        name=group.name,
+        status=group.status,
+        enable=group.enable,
+        enable_chat=group.enable_chat,
+        chat_mode=group.chat_mode,
+        sanity_limit=group.sanity_limit,
+        allow_r18g=group.allow_r18g,
+        allow_setu=group.allow_setu,
+        admin_ids=group.admin_ids or [],
+        message_count=message_count or 0,
+        last_activity=last_activity,
+        recent_messages=recent_messages,
+    )
+
+
+@router.put("/{group_id}", response_model=GroupDetail)
+async def update_group(group_id: int, payload: GroupUpdate) -> GroupDetail:
+    """Update a group's configuration and return the updated detail object."""
+
+    async with engine.new_session() as session:
+        group = await session.get(Group, group_id)
+        if group is None:
+            raise HTTPException(status_code=404, detail="Group not found")
+
+        update_data = payload.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(group, field, value)
+
+        await session.commit()
+        await session.refresh(group)
+
+        stats = (
+            await session.execute(
+                select(
+                    func.count(GroupChatHistory.message_id),
+                    func.max(GroupChatHistory.sent_at),
+                ).where(GroupChatHistory.group_id == group_id)
+            )
+        ).one()
+        message_count, last_activity = stats
+
+        recent = (
+            await session.execute(
+                select(GroupChatHistory)
+                .where(GroupChatHistory.group_id == group_id)
+                .order_by(desc(GroupChatHistory.sent_at))
+                .limit(20)
+            )
+        ).scalars().all()
+
+    recent_messages = [
+        ChatMessage(
+            message_id=msg.message_id,
+            user_id=msg.user_id,
+            type=msg.type.value,
+            bot_send=msg.bot_send,
+            text=msg.text,
+            sent_at=msg.sent_at,
+        )
+        for msg in recent
+    ]
+
+    return GroupDetail(
+        id=group.id,
+        name=group.name,
+        status=group.status,
+        enable=group.enable,
+        enable_chat=group.enable_chat,
+        chat_mode=group.chat_mode,
+        sanity_limit=group.sanity_limit,
+        allow_r18g=group.allow_r18g,
+        allow_setu=group.allow_setu,
+        admin_ids=group.admin_ids or [],
+        message_count=message_count or 0,
+        last_activity=last_activity,
+        recent_messages=recent_messages,
+    )
+
+
+@router.get("/{group_id}/history", response_model=list[ChatMessage])
+async def get_group_history(
+    group_id: int,
+    limit: int = Query(default=50, ge=1, le=200),
+    before: datetime | None = Query(default=None, description="Return messages before timestamp"),
+) -> list[ChatMessage]:
+    """Return a paginated slice of group chat history."""
+
+    async with engine.new_session() as session:
+        stmt = select(GroupChatHistory).where(GroupChatHistory.group_id == group_id)
+        if before is not None:
+            stmt = stmt.where(GroupChatHistory.sent_at < before)
+        stmt = stmt.order_by(desc(GroupChatHistory.sent_at)).limit(limit)
+        rows = (await session.execute(stmt)).scalars().all()
+
+    return [
+        ChatMessage(
+            message_id=row.message_id,
+            user_id=row.user_id,
+            type=row.type.value,
+            bot_send=row.bot_send,
+            text=row.text,
+            sent_at=row.sent_at,
+        )
+        for row in rows
+    ]

--- a/routers/private.py
+++ b/routers/private.py
@@ -1,0 +1,284 @@
+"""Private chat management API endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import String, cast, desc, func, or_, select
+
+from defines import MessageType, UserStatus
+from models import PrivateChatHistory, User
+from registries.engine import engine
+
+router = APIRouter(prefix="/api/private", tags=["private"])
+
+
+class EnumOption(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
+    label: str
+    value: str
+
+
+class PrivateMessage(BaseModel):
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
+
+    message_id: int
+    type: MessageType
+    bot_send: bool
+    text: str | None
+    sent_at: datetime | None
+
+
+class UserBase(BaseModel):
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
+
+    id: int
+    nick_name: str | None
+    status: UserStatus
+    enable_chat: bool
+    sanity_limit: int
+    allow_r18g: bool
+
+
+class PrivateUserListItem(UserBase):
+    message_count: int
+    last_activity: datetime | None
+
+
+class PrivateUserListResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    total: int
+    items: list[PrivateUserListItem]
+
+
+class PrivateUserDetail(PrivateUserListItem):
+    recent_messages: list[PrivateMessage]
+
+
+class PrivateUserUpdate(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
+    nick_name: str | None = None
+    enable_chat: bool | None = None
+    sanity_limit: int | None = Field(default=None, ge=0)
+    allow_r18g: bool | None = None
+    status: UserStatus | None = None
+
+
+def _apply_filters(stmt, *, search: str | None, chat_enabled: bool | None, status: UserStatus | None):
+    if search:
+        like_term = f"%{search}%"
+        stmt = stmt.where(
+            or_(
+                cast(User.id, String).ilike(like_term),
+                User.nick_name.ilike(like_term),
+            )
+        )
+    if chat_enabled is not None:
+        stmt = stmt.where(User.enable_chat.is_(chat_enabled))
+    if status is not None:
+        stmt = stmt.where(User.status == status)
+    return stmt
+
+
+@router.get("/meta", response_model=dict)
+async def get_private_meta() -> dict[str, Any]:
+    """Return enum metadata for private user management."""
+
+    return {
+        "statuses": [
+            EnumOption(label=status.name.title(), value=status.value) for status in UserStatus
+        ]
+    }
+
+
+@router.get("/users", response_model=PrivateUserListResponse)
+async def list_private_users(
+    q: str | None = Query(default=None, description="Search by user id or nickname"),
+    chat_enabled: bool | None = Query(default=None, description="Filter by chat availability"),
+    status: UserStatus | None = Query(default=None, description="Filter by user status"),
+    limit: int = Query(default=25, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> PrivateUserListResponse:
+    """List private users along with message statistics."""
+
+    async with engine.new_session() as session:
+        stmt = (
+            select(
+                User,
+                func.count(PrivateChatHistory.message_id).label("message_count"),
+                func.max(PrivateChatHistory.sent_at).label("last_activity"),
+            )
+            .outerjoin(PrivateChatHistory, PrivateChatHistory.user_id == User.id)
+            .group_by(User.id)
+        )
+
+        stmt = _apply_filters(stmt, search=q, chat_enabled=chat_enabled, status=status)
+        stmt = stmt.order_by(User.id).limit(limit).offset(offset)
+        result = await session.execute(stmt)
+        rows = result.all()
+
+        count_stmt = select(func.count()).select_from(User)
+        count_stmt = _apply_filters(count_stmt, search=q, chat_enabled=chat_enabled, status=status)
+        total = (await session.execute(count_stmt)).scalar_one()
+
+    items = [
+        PrivateUserListItem(
+            id=row.User.id,
+            nick_name=row.User.nick_name,
+            status=row.User.status,
+            enable_chat=row.User.enable_chat,
+            sanity_limit=row.User.sanity_limit,
+            allow_r18g=row.User.allow_r18g,
+            message_count=row.message_count or 0,
+            last_activity=row.last_activity,
+        )
+        for row in rows
+    ]
+
+    return PrivateUserListResponse(total=total, items=items)
+
+
+@router.get("/users/{user_id}", response_model=PrivateUserDetail)
+async def get_private_user(
+    user_id: int, recent_limit: int = Query(default=20, ge=1, le=50)
+) -> PrivateUserDetail:
+    """Retrieve detail and recent activity for a single user."""
+
+    async with engine.new_session() as session:
+        user = await session.get(User, user_id)
+        if user is None:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        stats = (
+            await session.execute(
+                select(
+                    func.count(PrivateChatHistory.message_id),
+                    func.max(PrivateChatHistory.sent_at),
+                ).where(PrivateChatHistory.user_id == user_id)
+            )
+        ).one()
+        message_count, last_activity = stats
+
+        recent = (
+            await session.execute(
+                select(PrivateChatHistory)
+                .where(PrivateChatHistory.user_id == user_id)
+                .order_by(desc(PrivateChatHistory.sent_at))
+                .limit(recent_limit)
+            )
+        ).scalars().all()
+
+    recent_messages = [
+        PrivateMessage(
+            message_id=msg.message_id,
+            type=msg.type,
+            bot_send=msg.bot_send,
+            text=msg.text,
+            sent_at=msg.sent_at,
+        )
+        for msg in recent
+    ]
+
+    return PrivateUserDetail(
+        id=user.id,
+        nick_name=user.nick_name,
+        status=user.status,
+        enable_chat=user.enable_chat,
+        sanity_limit=user.sanity_limit,
+        allow_r18g=user.allow_r18g,
+        message_count=message_count or 0,
+        last_activity=last_activity,
+        recent_messages=recent_messages,
+    )
+
+
+@router.put("/users/{user_id}", response_model=PrivateUserDetail)
+async def update_private_user(user_id: int, payload: PrivateUserUpdate) -> PrivateUserDetail:
+    """Update private user preferences and return the updated detail."""
+
+    async with engine.new_session() as session:
+        user = await session.get(User, user_id)
+        if user is None:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        update_data = payload.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(user, field, value)
+
+        await session.commit()
+        await session.refresh(user)
+
+        stats = (
+            await session.execute(
+                select(
+                    func.count(PrivateChatHistory.message_id),
+                    func.max(PrivateChatHistory.sent_at),
+                ).where(PrivateChatHistory.user_id == user_id)
+            )
+        ).one()
+        message_count, last_activity = stats
+
+        recent = (
+            await session.execute(
+                select(PrivateChatHistory)
+                .where(PrivateChatHistory.user_id == user_id)
+                .order_by(desc(PrivateChatHistory.sent_at))
+                .limit(20)
+            )
+        ).scalars().all()
+
+    recent_messages = [
+        PrivateMessage(
+            message_id=msg.message_id,
+            type=msg.type,
+            bot_send=msg.bot_send,
+            text=msg.text,
+            sent_at=msg.sent_at,
+        )
+        for msg in recent
+    ]
+
+    return PrivateUserDetail(
+        id=user.id,
+        nick_name=user.nick_name,
+        status=user.status,
+        enable_chat=user.enable_chat,
+        sanity_limit=user.sanity_limit,
+        allow_r18g=user.allow_r18g,
+        message_count=message_count or 0,
+        last_activity=last_activity,
+        recent_messages=recent_messages,
+    )
+
+
+@router.get("/users/{user_id}/history", response_model=list[PrivateMessage])
+async def get_private_history(
+    user_id: int,
+    limit: int = Query(default=50, ge=1, le=200),
+    before: datetime | None = Query(default=None, description="Messages before timestamp"),
+) -> list[PrivateMessage]:
+    """Return a slice of private chat history for a user."""
+
+    async with engine.new_session() as session:
+        stmt = select(PrivateChatHistory).where(PrivateChatHistory.user_id == user_id)
+        if before is not None:
+            stmt = stmt.where(PrivateChatHistory.sent_at < before)
+        stmt = stmt.order_by(desc(PrivateChatHistory.sent_at)).limit(limit)
+        rows = (await session.execute(stmt)).scalars().all()
+
+    return [
+        PrivateMessage(
+            message_id=row.message_id,
+            type=row.type,
+            bot_send=row.bot_send,
+            text=row.text,
+            sent_at=row.sent_at,
+        )
+        for row in rows
+    ]

--- a/webui/index.html
+++ b/webui/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ACG 图像管控控制台</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,0 +1,1551 @@
+{
+  "name": "acgimg-admin-console",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "acgimg-admin-console",
+      "version": "0.1.0",
+      "dependencies": {
+        "axios": "^1.6.7",
+        "primeflex": "^3.3.1",
+        "primeicons": "^6.0.1",
+        "primevue": "^3.52.0",
+        "vue": "^3.4.15",
+        "vue-router": "^4.3.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.24",
+        "@vitejs/plugin-vue": "^5.0.4",
+        "typescript": "^5.3.3",
+        "vite": "^5.1.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.3.tgz",
+      "integrity": "sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.3.tgz",
+      "integrity": "sha512-wd+u7SLT/u6knklV/ifG7gr5Qy4GUbH2hMWcDauPFJzmCZUAJ8L2bTkVXC2niOIxp8lk3iH/QX8kSrUxVZrOVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.3.tgz",
+      "integrity": "sha512-lj9ViATR1SsqycwFkJCtYfQTheBdvlWJqzqxwc9f2qrcVrQaF/gCuBRTiTolkRWS6KvNxSk4KHZWG7tDktLgjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.3.tgz",
+      "integrity": "sha512-+Dyo7O1KUmIsbzx1l+4V4tvEVnVQqMOIYtrxK7ncLSknl1xnMHLgn7gddJVrYPNZfEB8CIi3hK8gq8bDhb3h5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.3.tgz",
+      "integrity": "sha512-u9Xg2FavYbD30g3DSfNhxgNrxhi6xVG4Y6i9Ur1C7xUuGDW3banRbXj+qgnIrwRN4KeJ396jchwy9bCIzbyBEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.3.tgz",
+      "integrity": "sha512-5M8kyi/OX96wtD5qJR89a/3x5x8x5inXBZO04JWhkQb2JWavOWfjgkdvUqibGJeNNaz1/Z1PPza5/tAPXICI6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.3.tgz",
+      "integrity": "sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.3.tgz",
+      "integrity": "sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.3.tgz",
+      "integrity": "sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.3.tgz",
+      "integrity": "sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.3.tgz",
+      "integrity": "sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.3.tgz",
+      "integrity": "sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.3.tgz",
+      "integrity": "sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.3.tgz",
+      "integrity": "sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.3.tgz",
+      "integrity": "sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.3.tgz",
+      "integrity": "sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.3.tgz",
+      "integrity": "sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.3.tgz",
+      "integrity": "sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.3.tgz",
+      "integrity": "sha512-+zteHZdoUYLkyYKObGHieibUFLbttX2r+58l27XZauq0tcWYYuKUwY2wjeCN9oK1Um2YgH2ibd6cnX/wFD7DuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.3.tgz",
+      "integrity": "sha512-of1iHkTQSo3kr6dTIRX6t81uj/c/b15HXVsPcEElN5sS859qHrOepM5p9G41Hah+CTqSh2r8Bm56dL2z9UQQ7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.3.tgz",
+      "integrity": "sha512-s0hybmlHb56mWVZQj8ra9048/WZTPLILKxcvcq+8awSZmyiSUZjjem1AhU3Tf4ZKpYhK4mg36HtHDOe8QJS5PQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.3.tgz",
+      "integrity": "sha512-zGIbEVVXVtauFgl3MRwGWEN36P5ZGenHRMgNw88X5wEhEBpq0XrMEZwOn07+ICrwM17XO5xfMZqh0OldCH5VTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.18.tgz",
+      "integrity": "sha512-KeYVbfnbsBCyKG8e3gmUqAfyZNcoj/qpEbHRkQkfZdKOBrU7QQ+BsTdfqLSWX9/m1ytYreMhpKvp+EZi3UFYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.22.tgz",
+      "integrity": "sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.4",
+        "@vue/shared": "3.5.22",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.22.tgz",
+      "integrity": "sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.22",
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.22.tgz",
+      "integrity": "sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.4",
+        "@vue/compiler-core": "3.5.22",
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/compiler-ssr": "3.5.22",
+        "@vue/shared": "3.5.22",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.19",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.22.tgz",
+      "integrity": "sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.22.tgz",
+      "integrity": "sha512-f2Wux4v/Z2pqc9+4SmgZC1p73Z53fyD90NFWXiX9AKVnVBEvLFOWCEgJD3GdGnlxPZt01PSlfmLqbLYzY/Fw4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.22.tgz",
+      "integrity": "sha512-EHo4W/eiYeAzRTN5PCextDUZ0dMs9I8mQ2Fy+OkzvRPUYQEyK9yAjbasrMCXbLNhF7P0OUyivLjIy0yc6VrLJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.22",
+        "@vue/shared": "3.5.22"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.22.tgz",
+      "integrity": "sha512-Av60jsryAkI023PlN7LsqrfPvwfxOd2yAwtReCjeuugTJTkgrksYJJstg1e12qle0NarkfhfFu1ox2D+cQotww==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.22",
+        "@vue/runtime-core": "3.5.22",
+        "@vue/shared": "3.5.22",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.22.tgz",
+      "integrity": "sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.22",
+        "@vue/shared": "3.5.22"
+      },
+      "peerDependencies": {
+        "vue": "3.5.22"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.22.tgz",
+      "integrity": "sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==",
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-generator-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-generator-function/-/async-generator-function-1.0.0.tgz",
+      "integrity": "sha512-+NAXNqgCrB95ya4Sr66i1CL2hqLVckAk7xwRYWdcm39/ELQ6YNn1aw5r0bdQtqNZgQpEWzc5yc/igXc7aL5SLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.0.tgz",
+      "integrity": "sha512-xPypGGincdfyl/AiSGa7GjXLkvld9V7GjZlowup9SHIJnQnHLFiLODCd/DqKOp0PBagbHJ68r1KJI9Mut7m4sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.1.tgz",
+      "integrity": "sha512-fk1ZVEeOX9hVZ6QzoBNEC55+Ucqg4sTVwrVuigZhuRPESVFpMyXnd3sbXvPOwp7Y9riVyANiqhEuRF0G1aVSeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "async-generator-function": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/primeflex": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/primeflex/-/primeflex-3.3.1.tgz",
+      "integrity": "sha512-zaOq3YvcOYytbAmKv3zYc+0VNS9Wg5d37dfxZnveKBFPr7vEIwfV5ydrpiouTft8MVW6qNjfkaQphHSnvgQbpQ==",
+      "license": "MIT"
+    },
+    "node_modules/primeicons": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/primeicons/-/primeicons-6.0.1.tgz",
+      "integrity": "sha512-KDeO94CbWI4pKsPnYpA1FPjo79EsY9I+M8ywoPBSf9XMXoe/0crjbUK7jcQEDHuc0ZMRIZsxH3TYLv4TUtHmAA==",
+      "license": "MIT"
+    },
+    "node_modules/primevue": {
+      "version": "3.53.1",
+      "resolved": "https://registry.npmjs.org/primevue/-/primevue-3.53.1.tgz",
+      "integrity": "sha512-Bp4peZPdhfKYXwvtsOGGh5dfgmTelm+LZEZKGs/c5mOHhsUJ6xi3EcOZoQVI6oklS946ayMQvgD5L0S7itGO0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.3.tgz",
+      "integrity": "sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.3",
+        "@rollup/rollup-android-arm64": "4.52.3",
+        "@rollup/rollup-darwin-arm64": "4.52.3",
+        "@rollup/rollup-darwin-x64": "4.52.3",
+        "@rollup/rollup-freebsd-arm64": "4.52.3",
+        "@rollup/rollup-freebsd-x64": "4.52.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.3",
+        "@rollup/rollup-linux-arm64-musl": "4.52.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.3",
+        "@rollup/rollup-linux-x64-gnu": "4.52.3",
+        "@rollup/rollup-linux-x64-musl": "4.52.3",
+        "@rollup/rollup-openharmony-arm64": "4.52.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.3",
+        "@rollup/rollup-win32-x64-gnu": "4.52.3",
+        "@rollup/rollup-win32-x64-msvc": "4.52.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.22",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.22.tgz",
+      "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.22",
+        "@vue/compiler-sfc": "3.5.22",
+        "@vue/runtime-dom": "3.5.22",
+        "@vue/server-renderer": "3.5.22",
+        "@vue/shared": "3.5.22"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    }
+  }
+}

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "acgimg-admin-console",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "primeflex": "^3.3.1",
+    "primeicons": "^6.0.1",
+    "primevue": "^3.52.0",
+    "vue": "^3.4.15",
+    "vue-router": "^4.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.24",
+    "@vitejs/plugin-vue": "^5.0.4",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.0"
+  }
+}

--- a/webui/public/favicon.svg
+++ b/webui/public/favicon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#g)" />
+  <path
+    d="M18 20h28l-4 8h-8l-4 8h8l-4 8H18l4-8h8l4-8h-8z"
+    fill="#fff"
+    stroke="#0f172a"
+    stroke-width="2"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useRoute, useRouter, RouterView } from 'vue-router';
+
+import AppHeader from '@/components/AppHeader.vue';
+import AppSidebar from '@/components/AppSidebar.vue';
+
+const router = useRouter();
+const route = useRoute();
+
+const navItems = [
+  { label: '仪表盘', icon: 'pi pi-chart-line', to: '/dashboard' },
+  { label: '群组管理', icon: 'pi pi-users', to: '/groups' },
+  { label: '私聊管理', icon: 'pi pi-comments', to: '/private' },
+  { label: '功能配置', icon: 'pi pi-sliders-h', to: '/features' }
+];
+
+const activePath = computed(() => route.path);
+
+function handleNavigate(path: string) {
+  if (path !== route.path) {
+    router.push(path);
+  }
+}
+</script>
+
+<template>
+  <div class="layout-shell">
+    <AppHeader :items="navItems" :active-path="activePath" @navigate="handleNavigate" />
+    <div class="layout-content">
+      <AppSidebar
+        class="layout-sidebar"
+        :items="navItems"
+        :active-path="activePath"
+        @navigate="handleNavigate"
+      />
+      <main class="layout-main">
+        <RouterView />
+      </main>
+    </div>
+  </div>
+</template>

--- a/webui/src/components/ActivityTimeline.vue
+++ b/webui/src/components/ActivityTimeline.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import Timeline from 'primevue/timeline';
+import Card from 'primevue/card';
+import Tag from 'primevue/tag';
+
+export interface ActivityEntry {
+  message_id: number;
+  scope: string;
+  scope_id: number;
+  preview: string | null;
+  sent_at: string | null;
+}
+
+const props = defineProps<{ entries: ActivityEntry[] }>();
+
+function scopeLabel(scope: string) {
+  switch (scope) {
+    case 'group':
+      return { label: '群消息', severity: 'info' } as const;
+    case 'group_bot':
+      return { label: '机器人群推送', severity: 'success' } as const;
+    case 'private':
+      return { label: '私聊消息', severity: 'warn' } as const;
+    case 'private_bot':
+      return { label: '机器人私聊', severity: 'help' } as const;
+    default:
+      return { label: scope, severity: 'secondary' } as const;
+  }
+}
+</script>
+
+<template>
+  <Timeline :value="props.entries" align="alternate" class="w-full">
+    <template #opposite="slotProps">
+      <span class="text-sm text-color-secondary">
+        {{ slotProps.item.sent_at ? new Date(slotProps.item.sent_at).toLocaleString() : '未知时间' }}
+      </span>
+    </template>
+    <template #marker="slotProps">
+      <span class="flex align-items-center justify-content-center w-2rem h-2rem border-circle bg-primary text-white">
+        <i class="pi pi-bolt"></i>
+      </span>
+    </template>
+    <template #content="slotProps">
+      <Card class="shadow-1">
+        <template #title>
+          <div class="flex align-items-center justify-content-between">
+            <span class="text-sm">消息 ID #{{ slotProps.item.message_id }}</span>
+            <Tag :value="scopeLabel(slotProps.item.scope).label" :severity="scopeLabel(slotProps.item.scope).severity" />
+          </div>
+        </template>
+        <template #content>
+          <div class="text-color-secondary text-sm">对象 ID：{{ slotProps.item.scope_id }}</div>
+          <p class="mt-2 mb-0 white-space-pre-line">
+            {{ slotProps.item.preview ?? '暂无文本内容' }}
+          </p>
+        </template>
+      </Card>
+    </template>
+  </Timeline>
+</template>

--- a/webui/src/components/AppHeader.vue
+++ b/webui/src/components/AppHeader.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import Menubar from 'primevue/menubar';
+import type { MenuItem } from 'primevue/menuitem';
+
+interface NavItem {
+  label: string;
+  icon: string;
+  to: string;
+}
+
+const props = defineProps<{ items: NavItem[]; activePath: string }>();
+const emit = defineEmits<{ (e: 'navigate', to: string): void }>();
+
+const menuModel = computed<MenuItem[]>(() =>
+  props.items.map((item) => ({
+    label: item.label,
+    icon: item.icon,
+    command: () => emit('navigate', item.to),
+    class: { active: props.activePath.startsWith(item.to) }
+  }))
+);
+</script>
+
+<template>
+  <header class="surface-card border-bottom-1 surface-border">
+    <Menubar :model="menuModel" class="max-w-full border-none">
+      <template #start>
+        <div class="flex align-items-center gap-2 pl-2">
+          <i class="pi pi-shield text-primary text-xl"></i>
+          <span class="font-semibold text-lg">ACG 图像管控后台</span>
+        </div>
+      </template>
+      <template #end>
+        <div class="pr-3 text-sm text-color-secondary">
+          数据实时刷新，保障多群运营。
+        </div>
+      </template>
+    </Menubar>
+  </header>
+</template>

--- a/webui/src/components/AppSidebar.vue
+++ b/webui/src/components/AppSidebar.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import Listbox from 'primevue/listbox';
+
+interface NavItem {
+  label: string;
+  icon: string;
+  to: string;
+}
+
+const props = defineProps<{ items: NavItem[]; activePath: string }>();
+const emit = defineEmits<{ (e: 'navigate', to: string): void }>();
+
+interface SidebarOption {
+  to: string;
+  icon: string;
+  label: string;
+  value: string;
+}
+
+const options = computed<SidebarOption[]>(() =>
+  props.items.map((item) => ({
+    label: item.label,
+    value: item.to,
+    icon: item.icon,
+    to: item.to
+  }))
+);
+
+const selected = computed({
+  get: () => props.activePath,
+  set: (value: string) => emit('navigate', value)
+});
+</script>
+
+<template>
+  <aside class="h-full">
+    <div class="p-3 border-bottom-1 surface-border text-sm text-color-secondary">
+      控制台导航
+    </div>
+    <Listbox
+      v-model="selected"
+      :options="options"
+      optionLabel="label"
+      optionValue="value"
+      class="w-full border-none"
+    >
+      <template #option="{ option, selected }">
+        <div
+          class="flex align-items-center gap-2 px-3 py-2 border-round transition-colors"
+          :class="selected ? 'bg-primary-100 text-primary' : ''"
+        >
+          <i :class="[option.icon, 'text-lg']"></i>
+          <span class="font-medium">{{ option.label }}</span>
+        </div>
+      </template>
+    </Listbox>
+  </aside>
+</template>

--- a/webui/src/components/GroupDetailDialog.vue
+++ b/webui/src/components/GroupDetailDialog.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+import { computed, reactive, watch } from 'vue';
+import Dialog from 'primevue/dialog';
+import InputSwitch from 'primevue/inputswitch';
+import Dropdown from 'primevue/dropdown';
+import Chips from 'primevue/chips';
+import Button from 'primevue/button';
+import Divider from 'primevue/divider';
+import Tag from 'primevue/tag';
+import Timeline from 'primevue/timeline';
+
+import type { GroupDetail, GroupMeta, GroupUpdatePayload } from '@/services/api';
+
+const props = defineProps<{
+  visible: boolean;
+  meta: GroupMeta | null;
+  group: GroupDetail | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:visible', value: boolean): void;
+  (e: 'submit', value: GroupUpdatePayload): void;
+}>();
+
+const form = reactive<GroupUpdatePayload>({});
+
+watch(
+  () => props.group,
+  (group) => {
+    if (!group) {
+      Object.keys(form).forEach((key) => delete (form as any)[key]);
+      return;
+    }
+    form.name = group.name;
+    form.enable = group.enable;
+    form.enable_chat = group.enable_chat;
+    form.chat_mode = group.chat_mode;
+    form.sanity_limit = group.sanity_limit;
+    form.allow_r18g = group.allow_r18g;
+    form.allow_setu = group.allow_setu;
+    form.admin_ids = [...group.admin_ids];
+  },
+  { immediate: true }
+);
+
+const recentMessages = computed(() => props.group?.recent_messages ?? []);
+
+function close() {
+  emit('update:visible', false);
+}
+
+function save() {
+  const adminIds = (form.admin_ids ?? [])
+    .map((value) => (typeof value === 'number' ? value : Number.parseInt(String(value), 10)))
+    .filter((value) => Number.isFinite(value));
+
+  emit('submit', { ...form, admin_ids: adminIds });
+}
+</script>
+
+<template>
+  <Dialog
+    :visible="visible && !!group"
+    :modal="true"
+    header="群组详情"
+    style="width: min(800px, 95vw)"
+    @update:visible="emit('update:visible', $event)"
+  >
+    <template v-if="group">
+      <section class="grid gap-4">
+        <div class="col-12">
+          <h3 class="text-lg font-semibold mb-3">基础配置</h3>
+          <div class="grid formgrid p-fluid">
+            <div class="field col-12 md:col-6">
+              <label class="text-sm text-color-secondary">群名称</label>
+              <input v-model="form.name" type="text" class="p-inputtext" />
+            </div>
+            <div class="field col-12 md:col-6">
+              <label class="text-sm text-color-secondary">聊天模式</label>
+              <Dropdown
+                v-model="form.chat_mode"
+                :options="meta?.chat_modes ?? []"
+                optionLabel="label"
+                optionValue="value"
+                placeholder="选择聊天模式"
+              />
+            </div>
+            <div class="field col-6 md:col-3">
+              <label class="text-sm text-color-secondary">群启用</label>
+              <InputSwitch v-model="form.enable" />
+            </div>
+            <div class="field col-6 md:col-3">
+              <label class="text-sm text-color-secondary">允许聊天</label>
+              <InputSwitch v-model="form.enable_chat" />
+            </div>
+            <div class="field col-6 md:col-3">
+              <label class="text-sm text-color-secondary">允许涩图</label>
+              <InputSwitch v-model="form.allow_setu" />
+            </div>
+            <div class="field col-6 md:col-3">
+              <label class="text-sm text-color-secondary">允许 R18G</label>
+              <InputSwitch v-model="form.allow_r18g" />
+            </div>
+            <div class="field col-12 md:col-6">
+              <label class="text-sm text-color-secondary">理智值上限</label>
+              <input v-model.number="form.sanity_limit" type="number" class="p-inputtext" min="0" />
+            </div>
+            <div class="field col-12">
+              <label class="text-sm text-color-secondary">管理员 ID 列表</label>
+              <Chips v-model="form.admin_ids" separator="," />
+            </div>
+          </div>
+        </div>
+        <Divider />
+        <div class="col-12">
+          <h3 class="text-lg font-semibold mb-3">运行状态</h3>
+          <div class="flex gap-3 flex-wrap">
+            <Tag :value="`群 ID #${group.id}`" severity="info" />
+            <Tag :value="`状态 ${group.status}`" severity="help" />
+            <Tag :value="`消息量 ${group.message_count}`" severity="success" />
+            <Tag
+              :value="`最后活跃 ${group.last_activity ? new Date(group.last_activity).toLocaleString() : '暂无'}`"
+              severity="warning"
+            />
+          </div>
+        </div>
+        <Divider />
+        <div class="col-12">
+          <h3 class="text-lg font-semibold mb-3">近期消息</h3>
+          <Timeline :value="recentMessages" layout="vertical" align="left">
+            <template #marker>
+              <i class="pi pi-comment text-primary"></i>
+            </template>
+            <template #content="{ item }">
+              <div class="border-round surface-card p-3 shadow-1">
+                <div class="flex justify-content-between text-sm text-color-secondary">
+                  <span>消息 ID: {{ item.message_id }}</span>
+                  <span>{{ item.sent_at ? new Date(item.sent_at).toLocaleString() : '未知' }}</span>
+                </div>
+                <p class="mt-2 mb-0 white-space-pre-line text-sm">
+                  {{ item.text ?? '无内容' }}
+                </p>
+              </div>
+            </template>
+          </Timeline>
+        </div>
+      </section>
+    </template>
+    <template #footer>
+      <div v-if="group" class="flex justify-content-end gap-2">
+        <Button label="取消" severity="secondary" outlined @click="close" />
+        <Button label="保存" icon="pi pi-check" @click="save" />
+      </div>
+    </template>
+  </Dialog>
+</template>

--- a/webui/src/components/PrivateUserDialog.vue
+++ b/webui/src/components/PrivateUserDialog.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import { reactive, watch } from 'vue';
+import Dialog from 'primevue/dialog';
+import InputSwitch from 'primevue/inputswitch';
+import Dropdown from 'primevue/dropdown';
+import Button from 'primevue/button';
+import Tag from 'primevue/tag';
+import Divider from 'primevue/divider';
+import Timeline from 'primevue/timeline';
+
+import type { PrivateMeta, PrivateUserDetail, PrivateUserUpdatePayload } from '@/services/api';
+
+const props = defineProps<{
+  visible: boolean;
+  meta: PrivateMeta | null;
+  user: PrivateUserDetail | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:visible', value: boolean): void;
+  (e: 'submit', value: PrivateUserUpdatePayload): void;
+}>();
+
+const form = reactive<PrivateUserUpdatePayload>({});
+
+watch(
+  () => props.user,
+  (user) => {
+    if (!user) {
+      Object.keys(form).forEach((key) => delete (form as any)[key]);
+      return;
+    }
+    form.nick_name = user.nick_name;
+    form.enable_chat = user.enable_chat;
+    form.sanity_limit = user.sanity_limit;
+    form.allow_r18g = user.allow_r18g;
+    form.status = user.status;
+  },
+  { immediate: true }
+);
+
+function close() {
+  emit('update:visible', false);
+}
+
+function save() {
+  emit('submit', { ...form });
+}
+</script>
+
+<template>
+  <Dialog
+    :visible="visible && !!user"
+    :modal="true"
+    header="私聊用户详情"
+    style="width: min(720px, 95vw)"
+    @update:visible="emit('update:visible', $event)"
+  >
+    <template v-if="user">
+      <section class="grid gap-4">
+        <div class="col-12">
+          <h3 class="text-lg font-semibold mb-3">基础信息</h3>
+          <div class="grid formgrid p-fluid">
+            <div class="field col-12 md:col-6">
+              <label class="text-sm text-color-secondary">昵称</label>
+              <input v-model="form.nick_name" type="text" class="p-inputtext" />
+            </div>
+            <div class="field col-12 md:col-6">
+              <label class="text-sm text-color-secondary">状态</label>
+              <Dropdown
+                v-model="form.status"
+                :options="meta?.statuses ?? []"
+                optionLabel="label"
+                optionValue="value"
+              />
+            </div>
+            <div class="field col-6">
+              <label class="text-sm text-color-secondary">允许聊天</label>
+              <InputSwitch v-model="form.enable_chat" />
+            </div>
+            <div class="field col-6">
+              <label class="text-sm text-color-secondary">允许 R18G</label>
+              <InputSwitch v-model="form.allow_r18g" />
+            </div>
+            <div class="field col-12 md:col-6">
+              <label class="text-sm text-color-secondary">理智值上限</label>
+              <input v-model.number="form.sanity_limit" type="number" min="0" class="p-inputtext" />
+            </div>
+          </div>
+        </div>
+        <Divider />
+        <div class="col-12">
+          <h3 class="text-lg font-semibold mb-3">运行指标</h3>
+          <div class="flex gap-3 flex-wrap">
+            <Tag :value="`用户 ID #${user.id}`" severity="info" />
+            <Tag :value="`消息量 ${user.message_count}`" severity="success" />
+            <Tag
+              :value="`最后活跃 ${user.last_activity ? new Date(user.last_activity).toLocaleString() : '暂无'}`"
+              severity="warning"
+            />
+          </div>
+        </div>
+        <Divider />
+        <div class="col-12">
+          <h3 class="text-lg font-semibold mb-3">近期消息</h3>
+          <Timeline :value="user.recent_messages" layout="vertical" align="left">
+            <template #marker>
+              <i class="pi pi-inbox text-primary"></i>
+            </template>
+            <template #content="{ item }">
+              <div class="border-round surface-card p-3 shadow-1">
+                <div class="flex justify-content-between text-sm text-color-secondary">
+                  <span>消息 ID: {{ item.message_id }}</span>
+                  <span>{{ item.sent_at ? new Date(item.sent_at).toLocaleString() : '未知' }}</span>
+                </div>
+                <p class="mt-2 mb-0 white-space-pre-line text-sm">
+                  {{ item.text ?? '无内容' }}
+                </p>
+              </div>
+            </template>
+          </Timeline>
+        </div>
+      </section>
+    </template>
+    <template #footer>
+      <div v-if="user" class="flex justify-content-end gap-2">
+        <Button label="取消" severity="secondary" outlined @click="close" />
+        <Button label="保存" icon="pi pi-check" @click="save" />
+      </div>
+    </template>
+  </Dialog>
+</template>

--- a/webui/src/components/StatCard.vue
+++ b/webui/src/components/StatCard.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import Card from 'primevue/card';
+import Tag from 'primevue/tag';
+
+const props = defineProps<{
+  label: string;
+  value: number | string;
+  icon?: string;
+  accent?: 'primary' | 'success' | 'warning' | 'danger';
+  hint?: string;
+}>();
+</script>
+
+<template>
+  <Card class="h-full shadow-2 border-round-lg">
+    <template #title>
+      <div class="flex align-items-center justify-content-between">
+        <span class="text-sm text-color-secondary">{{ props.label }}</span>
+        <Tag v-if="hint" :value="hint" :severity="accent ?? 'primary'" rounded />
+      </div>
+    </template>
+    <template #content>
+      <div class="flex align-items-center gap-3 mt-2">
+        <i v-if="icon" :class="[icon, 'text-3xl', `text-${accent ?? 'primary'}`]"></i>
+        <span class="text-3xl font-semibold">{{ value }}</span>
+      </div>
+    </template>
+  </Card>
+</template>

--- a/webui/src/env.d.ts
+++ b/webui/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/webui/src/main.ts
+++ b/webui/src/main.ts
@@ -1,0 +1,22 @@
+import { createApp } from 'vue';
+import PrimeVue from 'primevue/config';
+import ToastService from 'primevue/toastservice';
+import ConfirmationService from 'primevue/confirmationservice';
+
+import App from './App.vue';
+import router from './router';
+
+import 'primevue/resources/themes/aura-light-blue/theme.css';
+import 'primevue/resources/primevue.min.css';
+import 'primeflex/primeflex.css';
+import 'primeicons/primeicons.css';
+import '@/styles/main.css';
+
+const app = createApp(App);
+
+app.use(PrimeVue, { ripple: true });
+app.use(ToastService);
+app.use(ConfirmationService);
+app.use(router);
+
+app.mount('#app');

--- a/webui/src/router/index.ts
+++ b/webui/src/router/index.ts
@@ -1,0 +1,37 @@
+import { createRouter, createWebHistory } from 'vue-router';
+
+const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes: [
+    {
+      path: '/',
+      redirect: '/dashboard'
+    },
+    {
+      path: '/dashboard',
+      name: 'dashboard',
+      component: () => import('@/views/DashboardView.vue')
+    },
+    {
+      path: '/groups',
+      name: 'groups',
+      component: () => import('@/views/GroupsView.vue')
+    },
+    {
+      path: '/private',
+      name: 'private',
+      component: () => import('@/views/PrivateChatsView.vue')
+    },
+    {
+      path: '/features',
+      name: 'features',
+      component: () => import('@/views/FeatureConfigView.vue')
+    },
+    {
+      path: '/:pathMatch(.*)*',
+      redirect: '/dashboard'
+    }
+  ]
+});
+
+export default router;

--- a/webui/src/services/api.ts
+++ b/webui/src/services/api.ts
@@ -1,0 +1,207 @@
+import axios from 'axios';
+
+const client = axios.create({
+  baseURL: '/api',
+  timeout: 15000
+});
+
+export interface DashboardActivityEntry {
+  message_id: number;
+  scope: string;
+  scope_id: number;
+  preview: string | null;
+  sent_at: string | null;
+}
+
+export interface DashboardSummary {
+  total_groups: number;
+  active_groups: number;
+  chat_enabled_groups: number;
+  total_users: number;
+  chat_enabled_users: number;
+  total_group_messages: number;
+  total_private_messages: number;
+  recent_activity: DashboardActivityEntry[];
+}
+
+export interface EnumOption {
+  label: string;
+  value: string;
+}
+
+export interface GroupMeta {
+  chat_modes: EnumOption[];
+  statuses: EnumOption[];
+}
+
+export interface ChatMessage {
+  message_id: number;
+  user_id: number | null;
+  type: string;
+  bot_send: boolean;
+  text: string | null;
+  sent_at: string | null;
+}
+
+export interface GroupListItem {
+  id: number;
+  name: string;
+  status: string;
+  enable: boolean;
+  enable_chat: boolean;
+  chat_mode: string | null;
+  sanity_limit: number;
+  allow_r18g: boolean;
+  allow_setu: boolean;
+  admin_ids: number[];
+  message_count: number;
+  last_activity: string | null;
+}
+
+export interface GroupListResponse {
+  total: number;
+  items: GroupListItem[];
+}
+
+export interface GroupDetail extends GroupListItem {
+  recent_messages: ChatMessage[];
+}
+
+export interface GroupListQuery {
+  q?: string;
+  enable?: boolean;
+  chat_enabled?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface GroupUpdatePayload {
+  name?: string | null;
+  enable?: boolean | null;
+  enable_chat?: boolean | null;
+  chat_mode?: string | null;
+  sanity_limit?: number | null;
+  allow_r18g?: boolean | null;
+  allow_setu?: boolean | null;
+  admin_ids?: number[] | null;
+}
+
+export interface PrivateMeta {
+  statuses: EnumOption[];
+}
+
+export interface PrivateMessage {
+  message_id: number;
+  user_id: number | null;
+  bot_send: boolean;
+  text: string | null;
+  sent_at: string | null;
+}
+
+export interface PrivateUserListItem {
+  id: number;
+  nick_name: string | null;
+  status: string;
+  enable_chat: boolean;
+  sanity_limit: number;
+  allow_r18g: boolean;
+  message_count: number;
+  last_activity: string | null;
+}
+
+export interface PrivateUserListResponse {
+  total: number;
+  items: PrivateUserListItem[];
+}
+
+export interface PrivateUserDetail extends PrivateUserListItem {
+  recent_messages: PrivateMessage[];
+}
+
+export interface PrivateUserListQuery {
+  q?: string;
+  chat_enabled?: boolean;
+  status?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface PrivateUserUpdatePayload {
+  nick_name?: string | null;
+  enable_chat?: boolean | null;
+  sanity_limit?: number | null;
+  allow_r18g?: boolean | null;
+  status?: string | null;
+}
+
+export interface FeatureFlag {
+  key: string;
+  label: string;
+  description: string;
+  value: boolean | null;
+  editable: boolean;
+  category: string;
+}
+
+export interface FeatureFlagResponse {
+  features: FeatureFlag[];
+  placeholders: FeatureFlag[];
+}
+
+export async function fetchDashboardSummary(): Promise<DashboardSummary> {
+  const { data } = await client.get<DashboardSummary>('/dashboard/summary');
+  return data;
+}
+
+export async function fetchGroupMeta(): Promise<GroupMeta> {
+  const { data } = await client.get<GroupMeta>('/groups/meta');
+  return data;
+}
+
+export async function listGroups(params: GroupListQuery): Promise<GroupListResponse> {
+  const { data } = await client.get<GroupListResponse>('/groups', { params });
+  return data;
+}
+
+export async function getGroupDetail(id: number): Promise<GroupDetail> {
+  const { data } = await client.get<GroupDetail>(`/groups/${id}`);
+  return data;
+}
+
+export async function updateGroup(id: number, payload: GroupUpdatePayload): Promise<GroupDetail> {
+  const { data } = await client.put<GroupDetail>(`/groups/${id}`, payload);
+  return data;
+}
+
+export async function fetchPrivateMeta(): Promise<PrivateMeta> {
+  const { data } = await client.get<PrivateMeta>('/private/meta');
+  return data;
+}
+
+export async function listPrivateUsers(params: PrivateUserListQuery): Promise<PrivateUserListResponse> {
+  const { data } = await client.get<PrivateUserListResponse>('/private/users', { params });
+  return data;
+}
+
+export async function getPrivateUserDetail(id: number): Promise<PrivateUserDetail> {
+  const { data } = await client.get<PrivateUserDetail>(`/private/users/${id}`);
+  return data;
+}
+
+export async function updatePrivateUser(
+  id: number,
+  payload: PrivateUserUpdatePayload
+): Promise<PrivateUserDetail> {
+  const { data } = await client.put<PrivateUserDetail>(`/private/users/${id}`, payload);
+  return data;
+}
+
+export async function fetchFeatureFlags(): Promise<FeatureFlagResponse> {
+  const { data } = await client.get<FeatureFlagResponse>('/config/features');
+  return data;
+}
+
+export async function updateFeatureFlag(key: string, value: boolean): Promise<FeatureFlag> {
+  const { data } = await client.put<FeatureFlag>(`/config/features/${key}`, { value });
+  return data;
+}

--- a/webui/src/styles/main.css
+++ b/webui/src/styles/main.css
@@ -1,0 +1,60 @@
+:root {
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  background-color: var(--surface-ground);
+  color: var(--text-color);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+#app {
+  min-height: 100vh;
+}
+
+.p-menubar-root-list > .p-menuitem.active > .p-menuitem-content {
+  background: color-mix(in srgb, var(--primary-color) 15%, transparent);
+}
+
+.layout-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.layout-content {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.layout-sidebar {
+  width: 16rem;
+  border-right: 1px solid var(--surface-border);
+  background: var(--surface-card);
+}
+
+.layout-main {
+  flex: 1;
+  min-height: 0;
+  padding: 1.5rem;
+  background: var(--surface-ground);
+}
+
+@media (max-width: 960px) {
+  .layout-content {
+    flex-direction: column;
+  }
+
+  .layout-sidebar {
+    width: 100%;
+    border-right: 0;
+    border-bottom: 1px solid var(--surface-border);
+  }
+}

--- a/webui/src/views/DashboardView.vue
+++ b/webui/src/views/DashboardView.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import Card from 'primevue/card';
+import Skeleton from 'primevue/skeleton';
+import Button from 'primevue/button';
+import Divider from 'primevue/divider';
+import Toast from 'primevue/toast';
+import { useToast } from 'primevue/usetoast';
+
+import StatCard from '@/components/StatCard.vue';
+import ActivityTimeline from '@/components/ActivityTimeline.vue';
+import type { DashboardSummary } from '@/services/api';
+import { fetchDashboardSummary } from '@/services/api';
+
+const toast = useToast();
+const loading = ref(true);
+const summary = ref<DashboardSummary | null>(null);
+
+async function loadSummary() {
+  loading.value = true;
+  try {
+    summary.value = await fetchDashboardSummary();
+  } catch (error) {
+    console.error(error);
+    toast.add({
+      severity: 'error',
+      summary: '加载失败',
+      detail: '无法获取仪表盘数据，请稍后重试。',
+      life: 4000
+    });
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(loadSummary);
+</script>
+
+<template>
+  <section class="flex flex-column gap-4">
+    <Toast />
+    <div class="flex align-items-center justify-content-between flex-wrap gap-3">
+      <div>
+        <h2 class="text-2xl font-semibold m-0">仪表盘</h2>
+        <p class="text-color-secondary mt-1 mb-0">
+          总览运营指标与最近消息动态。
+        </p>
+      </div>
+      <Button label="刷新" icon="pi pi-refresh" @click="loadSummary" :loading="loading" outlined />
+    </div>
+
+    <div class="grid" v-if="!loading && summary">
+      <div class="col-12 md:col-6 xl:col-3">
+        <StatCard
+          label="总群组"
+          :value="summary.total_groups"
+          icon="pi pi-building"
+          accent="primary"
+          :hint="`${summary.active_groups} 个活跃`"
+        />
+      </div>
+      <div class="col-12 md:col-6 xl:col-3">
+        <StatCard
+          label="启用聊天的群"
+          :value="summary.chat_enabled_groups"
+          icon="pi pi-microphone"
+          accent="success"
+          :hint="`${summary.total_group_messages} 条群消息`"
+        />
+      </div>
+      <div class="col-12 md:col-6 xl:col-3">
+        <StatCard
+          label="用户数量"
+          :value="summary.total_users"
+          icon="pi pi-user"
+          accent="primary"
+          :hint="`${summary.chat_enabled_users} 可聊天`"
+        />
+      </div>
+      <div class="col-12 md:col-6 xl:col-3">
+        <StatCard
+          label="私聊消息"
+          :value="summary.total_private_messages"
+          icon="pi pi-envelope"
+          accent="warning"
+          :hint="`近 ${summary.recent_activity.length} 条动态`"
+        />
+      </div>
+    </div>
+
+    <div v-else class="grid">
+      <div class="col-12 md:col-6 xl:col-3" v-for="index in 4" :key="index">
+        <Skeleton height="12rem" class="border-round-xl" />
+      </div>
+    </div>
+
+    <Card class="shadow-1">
+      <template #title>消息动态</template>
+      <template #content>
+        <template v-if="summary && summary.recent_activity.length">
+          <ActivityTimeline :entries="summary.recent_activity" />
+        </template>
+        <template v-else-if="loading">
+          <div class="grid">
+            <div class="col-12" v-for="index in 3" :key="index">
+              <Skeleton height="6rem" class="border-round" />
+            </div>
+          </div>
+        </template>
+        <template v-else>
+          <div class="text-center py-6 text-color-secondary">
+            暂无最新消息，系统保持稳定运行。
+          </div>
+        </template>
+      </template>
+    </Card>
+
+    <Card class="shadow-1">
+      <template #title>运营建议</template>
+      <template #content>
+        <p class="text-sm text-color-secondary mb-3">
+          根据最近的消息分布，建议关注以下重点：
+        </p>
+        <Divider />
+        <ul class="m-0 pl-3 text-sm">
+          <li>监控消息量激增的群组，合理设置理智值上限。</li>
+          <li>私聊活跃用户可适当启用更多功能，增强粘性。</li>
+          <li>预留功能配置已准备就绪，可随业务升级逐步开放。</li>
+        </ul>
+      </template>
+    </Card>
+  </section>
+</template>

--- a/webui/src/views/FeatureConfigView.vue
+++ b/webui/src/views/FeatureConfigView.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import Card from 'primevue/card';
+import InputSwitch from 'primevue/inputswitch';
+import Tag from 'primevue/tag';
+import Button from 'primevue/button';
+import Toast from 'primevue/toast';
+import { useToast } from 'primevue/usetoast';
+import Skeleton from 'primevue/skeleton';
+
+import type { FeatureFlag, FeatureFlagResponse } from '@/services/api';
+import { fetchFeatureFlags, updateFeatureFlag } from '@/services/api';
+
+const toast = useToast();
+const loading = ref(true);
+const features = ref<FeatureFlag[]>([]);
+const placeholders = ref<FeatureFlag[]>([]);
+
+const grouped = computed(() => {
+  const map = new Map<string, FeatureFlag[]>();
+  for (const feature of features.value) {
+    if (!map.has(feature.category)) {
+      map.set(feature.category, []);
+    }
+    map.get(feature.category)!.push(feature);
+  }
+  return Array.from(map.entries());
+});
+
+async function loadFlags() {
+  loading.value = true;
+  try {
+    const response: FeatureFlagResponse = await fetchFeatureFlags();
+    features.value = response.features;
+    placeholders.value = response.placeholders;
+  } catch (error) {
+    console.error(error);
+    toast.add({ severity: 'error', summary: '加载失败', detail: '无法获取功能配置。', life: 4000 });
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function toggleFlag(flag: FeatureFlag, value: boolean) {
+  if (!flag.editable) return;
+  try {
+    const updated = await updateFeatureFlag(flag.key, value);
+    features.value = features.value.map((item) => (item.key === updated.key ? updated : item));
+    toast.add({ severity: 'success', summary: '已更新', detail: `${flag.label} 已${value ? '启用' : '停用'}` });
+  } catch (error) {
+    console.error(error);
+    toast.add({ severity: 'error', summary: '更新失败', detail: '请稍后重试。', life: 4000 });
+  }
+}
+
+onMounted(loadFlags);
+</script>
+
+<template>
+  <section class="flex flex-column gap-4">
+    <Toast />
+    <header class="flex flex-column gap-2">
+      <h2 class="text-2xl font-semibold m-0">功能配置</h2>
+      <p class="text-color-secondary m-0">
+        管理全局功能开关，并预留未来拓展的配置位。
+      </p>
+      <Button label="刷新" icon="pi pi-refresh" outlined @click="loadFlags" :loading="loading" class="w-full md:w-auto" />
+    </header>
+
+    <div v-if="loading" class="grid">
+      <div class="col-12 md:col-6" v-for="index in 4" :key="index">
+        <Skeleton height="8rem" class="border-round" />
+      </div>
+    </div>
+
+    <div v-else class="grid gap-4">
+      <div class="col-12">
+        <h3 class="text-xl font-semibold mb-3">已上线功能</h3>
+        <div class="grid">
+          <div class="col-12 md:col-6" v-for="[category, items] in grouped" :key="category">
+            <Card class="shadow-1 h-full">
+              <template #title>
+                <div class="flex align-items-center justify-content-between">
+                  <span>{{ category }}</span>
+                  <Tag value="可配置" severity="info" />
+                </div>
+              </template>
+              <template #content>
+                <div class="flex flex-column gap-3">
+                  <div
+                    v-for="item in items"
+                    :key="item.key"
+                    class="flex justify-content-between gap-3 align-items-start"
+                  >
+                    <div class="flex flex-column gap-1">
+                      <span class="font-medium">{{ item.label }}</span>
+                      <span class="text-sm text-color-secondary">{{ item.description }}</span>
+                    </div>
+                    <InputSwitch
+                      :modelValue="item.value ?? false"
+                      :disabled="!item.editable"
+                      @update:modelValue="(value) => toggleFlag(item, value)"
+                    />
+                  </div>
+                </div>
+              </template>
+            </Card>
+          </div>
+        </div>
+      </div>
+
+      <div class="col-12">
+        <h3 class="text-xl font-semibold mb-3">预留能力</h3>
+        <div class="grid">
+          <div class="col-12 md:col-4" v-for="placeholder in placeholders" :key="placeholder.key">
+            <Card class="shadow-1 h-full">
+              <template #title>
+                <div class="flex align-items-center justify-content-between">
+                  <span>{{ placeholder.label }}</span>
+                  <Tag value="规划中" severity="warning" />
+                </div>
+              </template>
+              <template #content>
+                <p class="text-sm text-color-secondary mb-0">
+                  {{ placeholder.description }}
+                </p>
+              </template>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/webui/src/views/GroupsView.vue
+++ b/webui/src/views/GroupsView.vue
@@ -1,0 +1,231 @@
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue';
+import DataTable from 'primevue/datatable';
+import Column from 'primevue/column';
+import InputText from 'primevue/inputtext';
+import Dropdown from 'primevue/dropdown';
+import Button from 'primevue/button';
+import Tag from 'primevue/tag';
+import Toast from 'primevue/toast';
+import { useToast } from 'primevue/usetoast';
+import Skeleton from 'primevue/skeleton';
+
+import GroupDetailDialog from '@/components/GroupDetailDialog.vue';
+import type {
+  GroupDetail,
+  GroupListItem,
+  GroupMeta,
+  GroupUpdatePayload,
+  GroupListResponse,
+  GroupListQuery
+} from '@/services/api';
+import {
+  fetchGroupMeta,
+  getGroupDetail,
+  listGroups,
+  updateGroup
+} from '@/services/api';
+
+const toast = useToast();
+const loading = ref(true);
+const groups = ref<GroupListItem[]>([]);
+const meta = ref<GroupMeta | null>(null);
+const detail = ref<GroupDetail | null>(null);
+const dialogVisible = ref(false);
+
+const pagination = reactive({ page: 0, rows: 10, total: 0 });
+const filters = reactive<{ q: string; enable: boolean | null; chatEnabled: boolean | null }>({
+  q: '',
+  enable: null,
+  chatEnabled: null
+});
+
+async function ensureMeta() {
+  if (!meta.value) {
+    meta.value = await fetchGroupMeta();
+  }
+}
+
+async function loadGroups() {
+  loading.value = true;
+  try {
+    const query: GroupListQuery = {
+      q: filters.q || undefined,
+      enable: filters.enable === null ? undefined : filters.enable,
+      chat_enabled: filters.chatEnabled === null ? undefined : filters.chatEnabled,
+      limit: pagination.rows,
+      offset: pagination.page * pagination.rows
+    };
+    const response: GroupListResponse = await listGroups(query);
+    groups.value = response.items;
+    pagination.total = response.total;
+  } catch (error) {
+    console.error(error);
+    toast.add({
+      severity: 'error',
+      summary: '加载失败',
+      detail: '无法获取群组列表。',
+      life: 4000
+    });
+  } finally {
+    loading.value = false;
+  }
+}
+
+function onSearch() {
+  pagination.page = 0;
+  loadGroups();
+}
+
+function onPage(event: { page: number; rows: number }) {
+  pagination.page = event.page;
+  pagination.rows = event.rows;
+  loadGroups();
+}
+
+async function openDetail(groupId: number) {
+  try {
+    await ensureMeta();
+    detail.value = await getGroupDetail(groupId);
+    dialogVisible.value = true;
+  } catch (error) {
+    console.error(error);
+    toast.add({
+      severity: 'error',
+      summary: '加载失败',
+      detail: '无法获取群组详情。',
+      life: 4000
+    });
+  }
+}
+
+async function handleUpdate(payload: GroupUpdatePayload) {
+  if (!detail.value) return;
+  try {
+    const updated = await updateGroup(detail.value.id, payload);
+    detail.value = updated;
+    groups.value = groups.value.map((item) => (item.id === updated.id ? updated : item));
+    toast.add({ severity: 'success', summary: '保存成功', detail: '群组配置已更新。', life: 2500 });
+    await loadGroups();
+  } catch (error) {
+    console.error(error);
+    toast.add({ severity: 'error', summary: '保存失败', detail: '请稍后重试。', life: 4000 });
+  }
+}
+
+onMounted(async () => {
+  await ensureMeta();
+  await loadGroups();
+});
+</script>
+
+<template>
+  <section class="flex flex-column gap-4">
+    <Toast />
+    <header class="flex flex-column gap-2">
+      <h2 class="text-2xl font-semibold m-0">群组管理</h2>
+      <p class="text-color-secondary m-0">
+        查看机器人所覆盖的群组，快速调整群级别的权限与配置。
+      </p>
+      <div class="grid align-items-end gap-3">
+        <div class="col-12 md:col-4">
+          <label class="block text-sm text-color-secondary mb-2">搜索群 ID / 名称</label>
+          <span class="p-input-icon-left w-full">
+            <i class="pi pi-search" />
+            <InputText v-model="filters.q" placeholder="输入关键字" class="w-full" @keydown.enter="onSearch" />
+          </span>
+        </div>
+        <div class="col-6 md:col-3">
+          <label class="block text-sm text-color-secondary mb-2">启用状态</label>
+          <Dropdown
+            v-model="filters.enable"
+            :options="[
+              { label: '全部', value: null },
+              { label: '已启用', value: true },
+              { label: '未启用', value: false }
+            ]"
+            optionLabel="label"
+            optionValue="value"
+            class="w-full"
+            @change="onSearch"
+          />
+        </div>
+        <div class="col-6 md:col-3">
+          <label class="block text-sm text-color-secondary mb-2">聊天功能</label>
+          <Dropdown
+            v-model="filters.chatEnabled"
+            :options="[
+              { label: '全部', value: null },
+              { label: '已开放', value: true },
+              { label: '已关闭', value: false }
+            ]"
+            optionLabel="label"
+            optionValue="value"
+            class="w-full"
+            @change="onSearch"
+          />
+        </div>
+        <div class="col-12 md:col-2 flex md:justify-content-end">
+          <Button label="查询" icon="pi pi-filter" @click="onSearch" />
+        </div>
+      </div>
+    </header>
+
+    <DataTable
+      :value="groups"
+      :loading="loading"
+      dataKey="id"
+      responsiveLayout="scroll"
+      :rows="pagination.rows"
+      :first="pagination.page * pagination.rows"
+      :totalRecords="pagination.total"
+      paginator
+      lazy
+      :rowsPerPageOptions="[10, 20, 50]"
+      @page="onPage"
+      class="shadow-1 border-round-xl"
+      v-if="groups.length || !loading"
+    >
+      <Column field="id" header="群 ID" sortable />
+      <Column field="name" header="名称" sortable />
+      <Column header="状态">
+        <template #body="{ data }">
+          <Tag :value="data.enable ? '启用' : '停用'" :severity="data.enable ? 'success' : 'danger'" />
+        </template>
+      </Column>
+      <Column header="聊天">
+        <template #body="{ data }">
+          <Tag :value="data.enable_chat ? '开放' : '关闭'" :severity="data.enable_chat ? 'info' : 'warning'" />
+        </template>
+      </Column>
+      <Column header="消息量">
+        <template #body="{ data }">
+          <span class="font-medium">{{ data.message_count }}</span>
+        </template>
+      </Column>
+      <Column header="最后活跃">
+        <template #body="{ data }">
+          {{ data.last_activity ? new Date(data.last_activity).toLocaleString() : '暂无' }}
+        </template>
+      </Column>
+      <Column header="操作" style="width: 8rem">
+        <template #body="{ data }">
+          <Button label="详情" size="small" icon="pi pi-eye" @click="openDetail(data.id)" />
+        </template>
+      </Column>
+    </DataTable>
+
+    <div v-else class="grid">
+      <div class="col-12" v-for="index in 3" :key="index">
+        <Skeleton height="7rem" class="border-round" />
+      </div>
+    </div>
+
+    <GroupDetailDialog
+      v-model:visible="dialogVisible"
+      :meta="meta"
+      :group="detail"
+      @submit="handleUpdate"
+    />
+  </section>
+</template>

--- a/webui/src/views/PrivateChatsView.vue
+++ b/webui/src/views/PrivateChatsView.vue
@@ -1,0 +1,222 @@
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue';
+import DataTable from 'primevue/datatable';
+import Column from 'primevue/column';
+import InputText from 'primevue/inputtext';
+import Dropdown from 'primevue/dropdown';
+import Button from 'primevue/button';
+import Tag from 'primevue/tag';
+import Toast from 'primevue/toast';
+import { useToast } from 'primevue/usetoast';
+import Skeleton from 'primevue/skeleton';
+
+import PrivateUserDialog from '@/components/PrivateUserDialog.vue';
+import type {
+  PrivateMeta,
+  PrivateUserDetail,
+  PrivateUserListItem,
+  PrivateUserListResponse,
+  PrivateUserListQuery,
+  PrivateUserUpdatePayload
+} from '@/services/api';
+import {
+  fetchPrivateMeta,
+  getPrivateUserDetail,
+  listPrivateUsers,
+  updatePrivateUser
+} from '@/services/api';
+
+const toast = useToast();
+const loading = ref(true);
+const meta = ref<PrivateMeta | null>(null);
+const users = ref<PrivateUserListItem[]>([]);
+const detail = ref<PrivateUserDetail | null>(null);
+const dialogVisible = ref(false);
+
+const pagination = reactive({ page: 0, rows: 10, total: 0 });
+const filters = reactive<{ q: string; chatEnabled: boolean | null; status: string | null }>({
+  q: '',
+  chatEnabled: null,
+  status: null
+});
+
+const statusOptions = computed(() => [
+  { label: '全部状态', value: null },
+  ...(meta.value?.statuses ?? [])
+]);
+
+async function ensureMeta() {
+  if (!meta.value) {
+    meta.value = await fetchPrivateMeta();
+  }
+}
+
+async function loadUsers() {
+  loading.value = true;
+  try {
+    const query: PrivateUserListQuery = {
+      q: filters.q || undefined,
+      chat_enabled: filters.chatEnabled === null ? undefined : filters.chatEnabled,
+      status: filters.status || undefined,
+      limit: pagination.rows,
+      offset: pagination.page * pagination.rows
+    };
+    const response: PrivateUserListResponse = await listPrivateUsers(query);
+    users.value = response.items;
+    pagination.total = response.total;
+  } catch (error) {
+    console.error(error);
+    toast.add({ severity: 'error', summary: '加载失败', detail: '无法获取私聊用户列表。', life: 4000 });
+  } finally {
+    loading.value = false;
+  }
+}
+
+function onSearch() {
+  pagination.page = 0;
+  loadUsers();
+}
+
+function onPage(event: { page: number; rows: number }) {
+  pagination.page = event.page;
+  pagination.rows = event.rows;
+  loadUsers();
+}
+
+async function openDetail(userId: number) {
+  try {
+    await ensureMeta();
+    detail.value = await getPrivateUserDetail(userId);
+    dialogVisible.value = true;
+  } catch (error) {
+    console.error(error);
+    toast.add({ severity: 'error', summary: '加载失败', detail: '无法获取用户详情。', life: 4000 });
+  }
+}
+
+async function handleUpdate(payload: PrivateUserUpdatePayload) {
+  if (!detail.value) return;
+  try {
+    const updated = await updatePrivateUser(detail.value.id, payload);
+    detail.value = updated;
+    users.value = users.value.map((user) => (user.id === updated.id ? updated : user));
+    toast.add({ severity: 'success', summary: '保存成功', detail: '用户设置已更新。', life: 2500 });
+    await loadUsers();
+  } catch (error) {
+    console.error(error);
+    toast.add({ severity: 'error', summary: '保存失败', detail: '请稍后重试。', life: 4000 });
+  }
+}
+
+onMounted(async () => {
+  await ensureMeta();
+  await loadUsers();
+});
+</script>
+
+<template>
+  <section class="flex flex-column gap-4">
+    <Toast />
+    <header class="flex flex-column gap-2">
+      <h2 class="text-2xl font-semibold m-0">私聊管理</h2>
+      <p class="text-color-secondary m-0">
+        管理私聊用户的权限，追踪消息互动情况。
+      </p>
+      <div class="grid align-items-end gap-3">
+        <div class="col-12 md:col-4">
+          <label class="block text-sm text-color-secondary mb-2">搜索用户 ID / 昵称</label>
+          <span class="p-input-icon-left w-full">
+            <i class="pi pi-search" />
+            <InputText v-model="filters.q" placeholder="输入关键字" class="w-full" @keydown.enter="onSearch" />
+          </span>
+        </div>
+        <div class="col-6 md:col-3">
+          <label class="block text-sm text-color-secondary mb-2">聊天状态</label>
+          <Dropdown
+            v-model="filters.chatEnabled"
+            :options="[
+              { label: '全部', value: null },
+              { label: '可聊天', value: true },
+              { label: '已禁用', value: false }
+            ]"
+            optionLabel="label"
+            optionValue="value"
+            class="w-full"
+            @change="onSearch"
+          />
+        </div>
+        <div class="col-6 md:col-3">
+          <label class="block text-sm text-color-secondary mb-2">用户状态</label>
+          <Dropdown
+            v-model="filters.status"
+            :options="statusOptions"
+            optionLabel="label"
+            optionValue="value"
+            class="w-full"
+            @change="onSearch"
+          />
+        </div>
+        <div class="col-12 md:col-2 flex md:justify-content-end">
+          <Button label="查询" icon="pi pi-filter" @click="onSearch" />
+        </div>
+      </div>
+    </header>
+
+    <DataTable
+      :value="users"
+      :loading="loading"
+      dataKey="id"
+      responsiveLayout="scroll"
+      :rows="pagination.rows"
+      :first="pagination.page * pagination.rows"
+      :totalRecords="pagination.total"
+      paginator
+      lazy
+      :rowsPerPageOptions="[10, 20, 50]"
+      @page="onPage"
+      class="shadow-1 border-round-xl"
+      v-if="users.length || !loading"
+    >
+      <Column field="id" header="用户 ID" sortable />
+      <Column field="nick_name" header="昵称" sortable />
+      <Column header="聊天">
+        <template #body="{ data }">
+          <Tag :value="data.enable_chat ? '可用' : '禁用'" :severity="data.enable_chat ? 'success' : 'danger'" />
+        </template>
+      </Column>
+      <Column header="状态">
+        <template #body="{ data }">
+          <Tag :value="data.status" severity="info" />
+        </template>
+      </Column>
+      <Column header="消息量">
+        <template #body="{ data }">
+          <span class="font-medium">{{ data.message_count }}</span>
+        </template>
+      </Column>
+      <Column header="最后活跃">
+        <template #body="{ data }">
+          {{ data.last_activity ? new Date(data.last_activity).toLocaleString() : '暂无' }}
+        </template>
+      </Column>
+      <Column header="操作" style="width: 8rem">
+        <template #body="{ data }">
+          <Button label="详情" size="small" icon="pi pi-eye" @click="openDetail(data.id)" />
+        </template>
+      </Column>
+    </DataTable>
+
+    <div v-else class="grid">
+      <div class="col-12" v-for="index in 3" :key="index">
+        <Skeleton height="7rem" class="border-round" />
+      </div>
+    </div>
+
+    <PrivateUserDialog
+      v-model:visible="dialogVisible"
+      :meta="meta"
+      :user="detail"
+      @submit="handleUpdate"
+    />
+  </section>
+</template>

--- a/webui/tsconfig.json
+++ b/webui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/webui/tsconfig.node.json
+++ b/webui/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath, URL } from 'node:url';
+
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  base: '/admin/',
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
+  server: {
+    host: '0.0.0.0',
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- replace the legacy single-file admin page with a Vite-powered PrimeVue console composed of dashboard, group, private chat, and feature configuration views
- add a typed API service layer, routing, and shared layout components so the UI consumes the existing RESTful endpoints
- document the dev workflow and update FastAPI to serve the built assets when available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbebcdad18832f8c0d2d72f9467f13