### PR TITLE
Add command history tracking and surface it in the admin UI

### DIFF
--- a/handlers/command_handlers/admin_handler.py
+++ b/handlers/command_handlers/admin_handler.py
@@ -7,8 +7,10 @@ from telegram.constants import ParseMode
 import messase_generator
 from utils import is_group_type, delete_messages
 from registries import user_registry, group_registry, engine
+from services.command_history import command_logger
 
 
+@command_logger("admin")
 async def admin_handler_func(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
     处理机器人管理命令

--- a/handlers/command_handlers/option_handler.py
+++ b/handlers/command_handlers/option_handler.py
@@ -6,8 +6,10 @@ from telegram.ext import CommandHandler
 import messase_generator
 from utils import is_group_type, delete_messages
 from registries import user_registry, group_registry, engine
+from services.command_history import command_logger
 
 
+@command_logger("option")
 async def option_handler_func(update: Update, context) -> None:
     """
     处理用户配置命令

--- a/handlers/command_handlers/p_info_handler.py
+++ b/handlers/command_handlers/p_info_handler.py
@@ -2,8 +2,10 @@ from telegram import Update
 from telegram.ext import ContextTypes, CommandHandler
 
 from services import pixiv
+from services.command_history import command_logger
 
 
+@command_logger("pinfo")
 async def p_info_func(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not pixiv.enabled:
         await update.message.reply_text(

--- a/handlers/command_handlers/setu_handler.py
+++ b/handlers/command_handlers/setu_handler.py
@@ -10,8 +10,10 @@ from utils import is_group_type
 
 from registries import user_registry, group_registry
 from services.image_service import get_image
+from services.command_history import command_logger
 
 
+@command_logger("setu")
 async def setu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     user = await user_registry.get_user_by_id(update.effective_user.id)
     if user.status == UserStatus.BLOCKED:

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from bot import tg_bot
 
 from contextlib import asynccontextmanager
 from registries import engine, config_registry
-from routers import configs as config_routes, dashboard, groups, private
+from routers import configs as config_routes, dashboard, groups, private, commands
 import uvicorn
 
 from configs import config, db_config_declare
@@ -74,6 +74,7 @@ for router in (
     groups.router,
     private.router,
     config_routes.router,
+    commands.router,
 ):
     app.include_router(router)
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -6,3 +6,4 @@ from .active_message_handler import ActiveMessageHandler
 from .illustrations import Illustration, build_illust_from_api_dict
 from .group_chat_history import GroupChatHistory
 from .private_chat_history import PrivateChatHistory
+from .command_history import CommandHistory

--- a/models/command_history.py
+++ b/models/command_history.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from sqlalchemy import Boolean, Column, DateTime, Integer, JSON, String, Text
+from sqlalchemy.sql import func
+
+from configs import config as file_config
+
+from .base import Base
+
+
+class CommandHistory(Base):
+    __tablename__ = f"{file_config.db_prefix}command_history"
+
+    id = Column(Integer, primary_key=True, autoincrement=True, comment="记录 ID")
+    command = Column(String(64), nullable=False, index=True, comment="执行的命令名称")
+    user_id = Column(Integer, nullable=True, index=True, comment="触发命令的用户 ID")
+    chat_id = Column(Integer, nullable=True, index=True, comment="命令所在的会话 ID")
+    chat_type = Column(String(32), nullable=True, comment="会话类型，如 private 或 supergroup")
+    message_id = Column(Integer, nullable=True, comment="命令关联的消息 ID")
+    arguments = Column(JSON, nullable=True, comment="命令参数列表")
+    raw_text = Column(Text, nullable=True, comment="命令的原始文本内容")
+    success = Column(Boolean, nullable=False, default=True, comment="命令是否执行成功")
+    error_message = Column(Text, nullable=True, comment="命令执行失败时的错误信息")
+    duration_ms = Column(Integer, nullable=True, comment="命令处理耗时，单位毫秒")
+    triggered_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        comment="命令触发的时间",
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - 调试辅助
+        return (
+            f"<CommandHistory id={self.id} command={self.command!r} user_id={self.user_id} "
+            f"chat_id={self.chat_id} success={self.success}>"
+        )

--- a/registries/__init__.py
+++ b/registries/__init__.py
@@ -5,5 +5,6 @@ from . import (
     user_registry,
     group_registry,
     config_registry,
-    active_message_handler_registry
+    active_message_handler_registry,
+    command_history_registry,
 )

--- a/registries/command_history_registry.py
+++ b/registries/command_history_registry.py
@@ -1,0 +1,88 @@
+"""Persistence helpers for command execution history."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Sequence
+
+from sqlalchemy import and_, desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models import CommandHistory
+
+from .engine import engine
+
+
+async def record_command_execution(
+    *,
+    command: str,
+    user_id: int | None,
+    chat_id: int | None,
+    chat_type: str | None,
+    message_id: int | None,
+    arguments: Sequence[str] | None,
+    raw_text: str | None,
+    success: bool,
+    error_message: str | None,
+    duration_ms: int | None,
+    triggered_at: datetime,
+) -> CommandHistory:
+    """Persist a single command execution entry."""
+
+    payload = CommandHistory(
+        command=command,
+        user_id=user_id,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        message_id=message_id,
+        arguments=list(arguments) if arguments is not None else None,
+        raw_text=raw_text,
+        success=success,
+        error_message=error_message,
+        duration_ms=duration_ms,
+        triggered_at=triggered_at,
+    )
+
+    async with engine.new_session() as session:
+        session: AsyncSession = session
+        session.add(payload)
+        await session.commit()
+        await session.refresh(payload)
+        return payload
+
+
+async def query_history(
+    *,
+    command: str | None = None,
+    user_id: int | None = None,
+    success: bool | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[int, list[CommandHistory]]:
+    """Retrieve paginated command history entries applying optional filters."""
+
+    async with engine.new_session() as session:
+        session: AsyncSession = session
+
+        filters = []
+        if command:
+            filters.append(CommandHistory.command == command)
+        if user_id is not None:
+            filters.append(CommandHistory.user_id == user_id)
+        if success is not None:
+            filters.append(CommandHistory.success.is_(success))
+
+        stmt = select(CommandHistory)
+        if filters:
+            stmt = stmt.where(and_(*filters))
+        stmt = stmt.order_by(desc(CommandHistory.triggered_at)).limit(limit).offset(offset)
+
+        result = await session.execute(stmt)
+        items = result.scalars().all()
+
+        count_stmt = select(func.count()).select_from(CommandHistory)
+        if filters:
+            count_stmt = count_stmt.where(and_(*filters))
+        total = (await session.execute(count_stmt)).scalar_one()
+
+        return total, items

--- a/routers/__init__.py
+++ b/routers/__init__.py
@@ -1,10 +1,11 @@
 """FastAPI router registrations for the administrative API."""
 
-from . import dashboard, groups, private, configs
+from . import dashboard, groups, private, configs, commands
 
 __all__ = [
     "dashboard",
     "groups",
     "private",
     "configs",
+    "commands",
 ]

--- a/routers/commands.py
+++ b/routers/commands.py
@@ -1,0 +1,57 @@
+"""Endpoints for inspecting bot command execution history."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, ConfigDict
+
+from registries.command_history_registry import query_history
+
+router = APIRouter(prefix="/api/commands", tags=["commands"])
+
+
+class CommandHistoryEntry(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    command: str
+    user_id: int | None
+    chat_id: int | None
+    chat_type: str | None
+    message_id: int | None
+    arguments: list[str] | None
+    raw_text: str | None
+    success: bool
+    error_message: str | None
+    duration_ms: int | None
+    triggered_at: datetime
+
+
+class CommandHistoryResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    total: int
+    items: list[CommandHistoryEntry]
+
+
+@router.get("/history", response_model=CommandHistoryResponse)
+async def list_command_history(
+    command: str | None = Query(default=None, description="Filter by command name"),
+    user_id: int | None = Query(default=None, description="Filter by triggering user"),
+    success: bool | None = Query(default=None, description="Filter by execution outcome"),
+    limit: int = Query(default=25, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> CommandHistoryResponse:
+    """Return paginated command execution history entries."""
+
+    total, items = await query_history(
+        command=command,
+        user_id=user_id,
+        success=success,
+        limit=limit,
+        offset=offset,
+    )
+
+    return CommandHistoryResponse(total=total, items=items)

--- a/services/command_history.py
+++ b/services/command_history.py
@@ -1,0 +1,93 @@
+"""Utilities for recording command execution history."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from functools import wraps
+from typing import Awaitable, Callable, Sequence, TypeVar
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from registries import command_history_registry
+
+logger = logging.getLogger(__name__)
+
+F = TypeVar("F", bound=Callable[..., Awaitable[object]])
+
+
+def _safe_truncate(value: str | None, max_length: int = 500) -> str | None:
+    if value is None:
+        return None
+    if len(value) <= max_length:
+        return value
+    return value[: max_length - 1] + "…"
+
+
+def command_logger(command_name: str) -> Callable[[F], F]:
+    """Decorate a handler to automatically persist command execution details."""
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE, *args, **kwargs):
+            started_at = datetime.now(timezone.utc)
+            success = False
+            error_message: str | None = None
+            try:
+                result = await func(update, context, *args, **kwargs)
+                success = True
+                return result
+            except Exception as exc:  # noqa: BLE001 - 需要记录所有异常
+                error_message = _safe_truncate(str(exc))
+                raise
+            finally:
+                try:
+                    await _persist_history(
+                        command_name=command_name,
+                        update=update,
+                        context=context,
+                        success=success,
+                        error_message=error_message,
+                        started_at=started_at,
+                    )
+                except Exception:  # pragma: no cover - 日志记录即可
+                    logger.exception("Failed to record command history for %s", command_name)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+async def _persist_history(
+    *,
+    command_name: str,
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    success: bool,
+    error_message: str | None,
+    started_at: datetime,
+) -> None:
+    message = update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+
+    arguments: Sequence[str] | None = getattr(context, "args", None)
+    raw_text = message.text if message and message.text else None
+
+    ended_at = datetime.now(timezone.utc)
+    duration_ms = int((ended_at - started_at).total_seconds() * 1000)
+
+    await command_history_registry.record_command_execution(
+        command=command_name,
+        user_id=user.id if user else None,
+        chat_id=chat.id if chat else None,
+        chat_type=chat.type if chat else None,
+        message_id=message.message_id if message else None,
+        arguments=arguments,
+        raw_text=raw_text,
+        success=success,
+        error_message=error_message,
+        duration_ms=duration_ms,
+        triggered_at=started_at,
+    )

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -12,6 +12,7 @@ const navItems = [
   { label: '仪表盘', icon: 'pi pi-chart-line', to: '/dashboard' },
   { label: '群组管理', icon: 'pi pi-users', to: '/groups' },
   { label: '私聊管理', icon: 'pi pi-comments', to: '/private' },
+  { label: '命令历史', icon: 'pi pi-list', to: '/commands' },
   { label: '功能配置', icon: 'pi pi-sliders-h', to: '/features' }
 ];
 

--- a/webui/src/router/index.ts
+++ b/webui/src/router/index.ts
@@ -23,6 +23,11 @@ const router = createRouter({
       component: () => import('@/views/PrivateChatsView.vue')
     },
     {
+      path: '/commands',
+      name: 'commands',
+      component: () => import('@/views/CommandHistoryView.vue')
+    },
+    {
       path: '/features',
       name: 'features',
       component: () => import('@/views/FeatureConfigView.vue')

--- a/webui/src/services/api.ts
+++ b/webui/src/services/api.ts
@@ -24,6 +24,34 @@ export interface DashboardSummary {
   recent_activity: DashboardActivityEntry[];
 }
 
+export interface CommandHistoryItem {
+  id: number;
+  command: string;
+  user_id: number | null;
+  chat_id: number | null;
+  chat_type: string | null;
+  message_id: number | null;
+  arguments: string[] | null;
+  raw_text: string | null;
+  success: boolean;
+  error_message: string | null;
+  duration_ms: number | null;
+  triggered_at: string;
+}
+
+export interface CommandHistoryResponse {
+  total: number;
+  items: CommandHistoryItem[];
+}
+
+export interface CommandHistoryQuery {
+  command?: string;
+  user_id?: number;
+  success?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
 export interface EnumOption {
   label: string;
   value: string;
@@ -203,5 +231,12 @@ export async function fetchFeatureFlags(): Promise<FeatureFlagResponse> {
 
 export async function updateFeatureFlag(key: string, value: boolean): Promise<FeatureFlag> {
   const { data } = await client.put<FeatureFlag>(`/config/features/${key}`, { value });
+  return data;
+}
+
+export async function listCommandHistory(
+  params: CommandHistoryQuery
+): Promise<CommandHistoryResponse> {
+  const { data } = await client.get<CommandHistoryResponse>('/commands/history', { params });
   return data;
 }

--- a/webui/src/views/CommandHistoryView.vue
+++ b/webui/src/views/CommandHistoryView.vue
@@ -1,0 +1,190 @@
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue';
+import DataTable from 'primevue/datatable';
+import Column from 'primevue/column';
+import InputText from 'primevue/inputtext';
+import Dropdown from 'primevue/dropdown';
+import Button from 'primevue/button';
+import Tag from 'primevue/tag';
+import Toast from 'primevue/toast';
+import { useToast } from 'primevue/usetoast';
+import Skeleton from 'primevue/skeleton';
+
+import type { CommandHistoryItem, CommandHistoryQuery } from '@/services/api';
+import { listCommandHistory } from '@/services/api';
+
+const toast = useToast();
+const loading = ref(true);
+const entries = ref<CommandHistoryItem[]>([]);
+
+const pagination = reactive({ page: 0, rows: 20, total: 0 });
+const filters = reactive<{ command: string; userId: string; success: boolean | null }>({
+  command: '',
+  userId: '',
+  success: null
+});
+
+function parseUserId(): number | undefined {
+  const trimmed = filters.userId.trim();
+  if (!trimmed) return undefined;
+  const parsed = Number(trimmed);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+async function loadHistory() {
+  loading.value = true;
+  try {
+    const query: CommandHistoryQuery = {
+      command: filters.command.trim() || undefined,
+      user_id: parseUserId(),
+      success: filters.success === null ? undefined : filters.success,
+      limit: pagination.rows,
+      offset: pagination.page * pagination.rows
+    };
+    const { items, total } = await listCommandHistory(query);
+    entries.value = items;
+    pagination.total = total;
+  } catch (error) {
+    console.error(error);
+    toast.add({
+      severity: 'error',
+      summary: '加载失败',
+      detail: '无法获取命令历史记录。',
+      life: 4000
+    });
+  } finally {
+    loading.value = false;
+  }
+}
+
+function onSearch() {
+  pagination.page = 0;
+  loadHistory();
+}
+
+function onPage(event: { page: number; rows: number }) {
+  pagination.page = event.page;
+  pagination.rows = event.rows;
+  loadHistory();
+}
+
+function formatArguments(args: string[] | null): string {
+  if (!args || args.length === 0) return '—';
+  return args.join(' ');
+}
+
+function formatDuration(duration: number | null): string {
+  if (typeof duration !== 'number') return '—';
+  return `${duration} ms`;
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+onMounted(loadHistory);
+</script>
+
+<template>
+  <section class="flex flex-column gap-4">
+    <Toast />
+    <header class="flex flex-column gap-2">
+      <h2 class="text-2xl font-semibold m-0">命令历史</h2>
+      <p class="text-color-secondary m-0">
+        记录最近触发的机器人命令，帮助排查问题与追踪使用情况。
+      </p>
+      <div class="grid align-items-end gap-3">
+        <div class="col-12 md:col-4">
+          <label class="block text-sm text-color-secondary mb-2">命令名称</label>
+          <InputText v-model="filters.command" placeholder="如 setu" class="w-full" @keydown.enter="onSearch" />
+        </div>
+        <div class="col-12 md:col-3">
+          <label class="block text-sm text-color-secondary mb-2">用户 ID</label>
+          <InputText v-model="filters.userId" placeholder="精准匹配" class="w-full" @keydown.enter="onSearch" />
+        </div>
+        <div class="col-6 md:col-3">
+          <label class="block text-sm text-color-secondary mb-2">执行状态</label>
+          <Dropdown
+            v-model="filters.success"
+            :options="[
+              { label: '全部', value: null },
+              { label: '成功', value: true },
+              { label: '失败', value: false }
+            ]"
+            optionLabel="label"
+            optionValue="value"
+            class="w-full"
+            @change="onSearch"
+          />
+        </div>
+        <div class="col-12 md:col-2 flex md:justify-content-end">
+          <Button label="查询" icon="pi pi-search" @click="onSearch" />
+        </div>
+      </div>
+    </header>
+
+    <DataTable
+      v-if="entries.length || !loading"
+      :value="entries"
+      :loading="loading"
+      dataKey="id"
+      responsiveLayout="scroll"
+      :rows="pagination.rows"
+      :first="pagination.page * pagination.rows"
+      :totalRecords="pagination.total"
+      paginator
+      lazy
+      :rowsPerPageOptions="[20, 50, 100]"
+      @page="onPage"
+      class="shadow-1 border-round-xl"
+    >
+      <Column field="triggered_at" header="时间" sortable>
+        <template #body="{ data }">
+          {{ formatTimestamp(data.triggered_at) }}
+        </template>
+      </Column>
+      <Column field="command" header="命令" sortable />
+      <Column header="参数">
+        <template #body="{ data }">
+          {{ formatArguments(data.arguments) }}
+        </template>
+      </Column>
+      <Column header="用户">
+        <template #body="{ data }">
+          {{ data.user_id ?? '—' }}
+        </template>
+      </Column>
+      <Column header="会话">
+        <template #body="{ data }">
+          <div class="flex flex-column">
+            <span>{{ data.chat_id ?? '—' }}</span>
+            <small class="text-color-secondary">{{ data.chat_type ?? '未知' }}</small>
+          </div>
+        </template>
+      </Column>
+      <Column header="结果">
+        <template #body="{ data }">
+          <Tag :value="data.success ? '成功' : '失败'" :severity="data.success ? 'success' : 'danger'" />
+        </template>
+      </Column>
+      <Column header="耗时">
+        <template #body="{ data }">
+          {{ formatDuration(data.duration_ms) }}
+        </template>
+      </Column>
+      <Column header="错误信息" style="min-width: 16rem">
+        <template #body="{ data }">
+          <span class="text-sm">{{ data.error_message || '—' }}</span>
+        </template>
+      </Column>
+    </DataTable>
+
+    <div v-else class="grid">
+      <div class="col-12" v-for="index in 3" :key="index">
+        <Skeleton height="6rem" class="border-round" />
+      </div>
+    </div>
+  </section>
+</template>


### PR DESCRIPTION
## Summary
- add a dedicated CommandHistory model, registry helpers, and FastAPI router to persist and expose command executions
- wrap bot command handlers with a reusable decorator so every invocation is recorded with metadata and outcome
- extend the web console API bindings, navigation, and new CommandHistory view to browse and filter stored command runs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbfc3834f4832fbd1696ab552081d1