### PR TITLE
Add configurable Telegram cache with Redis support

### DIFF
--- a/handlers/callback_handlers/conf_handlers/bot/bot_conf_handler.py
+++ b/handlers/callback_handlers/conf_handlers/bot/bot_conf_handler.py
@@ -5,11 +5,13 @@ from .feature_flags import handle_feature_flag
 from .panel import refresh_bot_config_panel
 from .storage import handle_storage
 from .pixiv import handle_pixiv
+from .cache import handle_cache
 
 handler_map = {
     "feature": handle_feature_flag,
     "storage": handle_storage,
     "pixiv": handle_pixiv,
+    "cache": handle_cache,
 }
 
 

--- a/handlers/callback_handlers/conf_handlers/bot/cache.py
+++ b/handlers/callback_handlers/conf_handlers/bot/cache.py
@@ -1,0 +1,138 @@
+"""Callback handlers for Telegram cache configuration."""
+
+from __future__ import annotations
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import ContextTypes
+
+from registries import active_message_handler_registry, config_registry
+from services.telegram_cache import telegram_cache_manager
+
+from .panel import refresh_bot_config_panel
+
+
+def _build_menu(config: config_registry.TelegramCacheConfig) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+
+    rows.append(
+        [
+            InlineKeyboardButton(
+                f"使用内存缓存{' ✅' if config.backend == 'memory' else ''}",
+                callback_data="conf:bot:cache:set_backend:memory",
+            )
+        ]
+    )
+    rows.append(
+        [
+            InlineKeyboardButton(
+                f"使用 Redis 缓存{' ✅' if config.backend == 'redis' else ''}",
+                callback_data="conf:bot:cache:set_backend:redis",
+            )
+        ]
+    )
+
+    rows.append(
+        [
+            InlineKeyboardButton(
+                f"设置缓存 TTL (当前: {config.ttl_seconds}s)",
+                callback_data="conf:bot:cache:set_ttl",
+            )
+        ]
+    )
+
+    rows.append(
+        [
+            InlineKeyboardButton(
+                "配置 Redis 地址" if not config.redis_url else "更新 Redis 地址",
+                callback_data="conf:bot:cache:set_redis",
+            )
+        ]
+    )
+
+    if config.redis_url:
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    "清除 Redis 地址",
+                    callback_data="conf:bot:cache:clear_redis",
+                )
+            ]
+        )
+
+    rows.append([InlineKeyboardButton("返回", callback_data="conf:bot:panel:refresh")])
+
+    return InlineKeyboardMarkup(rows)
+
+
+async def handle_cache(update: Update, context: ContextTypes.DEFAULT_TYPE, cmd: list[str]) -> None:
+    query = update.callback_query
+    if query is None or not cmd:
+        return
+
+    action = cmd[0]
+    config = await config_registry.get_telegram_cache_config()
+
+    if action == "menu":
+        markup = _build_menu(config)
+        await context.bot.edit_message_reply_markup(
+            chat_id=update.effective_chat.id,
+            message_id=update.effective_message.message_id,
+            reply_markup=markup,
+        )
+        await query.answer("已打开缓存设置")
+        return
+
+    if action == "set_backend" and len(cmd) >= 2:
+        backend = cmd[1]
+        if backend not in {"memory", "redis"}:
+            await query.answer("不支持的缓存后端", show_alert=True)
+            return
+        await config_registry.set_telegram_cache_backend(backend)
+        await telegram_cache_manager.reset()
+        await query.answer(f"已切换缓存后端为 {backend}")
+        await refresh_bot_config_panel(
+            context,
+            chat_id=update.effective_chat.id,
+            message_id=update.effective_message.message_id,
+        )
+        return
+
+    if action == "set_ttl":
+        await active_message_handler_registry.set(
+            user_id=update.effective_user.id,
+            handler_id=f"set_cache_ttl:{update.effective_message.message_id}",
+        )
+        await query.answer("请输入新的缓存 TTL（秒）")
+        await context.bot.send_message(
+            chat_id=update.effective_chat.id,
+            text="请发送新的缓存 TTL（单位: 秒，最小 30）",
+        )
+        return
+
+    if action == "set_redis":
+        await active_message_handler_registry.set(
+            user_id=update.effective_user.id,
+            handler_id=f"set_cache_redis:{update.effective_message.message_id}",
+        )
+        await query.answer("请输入 Redis 地址")
+        await context.bot.send_message(
+            chat_id=update.effective_chat.id,
+            text=(
+                "请发送 Redis 连接地址，例如 redis://:password@host:6379/0。\n"
+                "若需清除，请发送单个减号 -。"
+            ),
+        )
+        return
+
+    if action == "clear_redis":
+        await config_registry.set_telegram_cache_redis_url(None)
+        await telegram_cache_manager.reset()
+        await query.answer("已清除 Redis 配置")
+        await refresh_bot_config_panel(
+            context,
+            chat_id=update.effective_chat.id,
+            message_id=update.effective_message.message_id,
+        )
+        return
+
+    await query.answer()

--- a/handlers/message_handlers/index.py
+++ b/handlers/message_handlers/index.py
@@ -2,10 +2,14 @@ from .root import root
 from .set_backblaze_appid import set_backblaze_appid
 from .set_user_nickname import set_user_nickname
 from .set_pixiv_token import set_pixiv_token
+from .set_cache_ttl import set_cache_ttl
+from .set_cache_redis import set_cache_redis
 
 index = {
     "root": root,
     "set_backblaze_appid": set_backblaze_appid,
     "set_user_nickname": set_user_nickname,
     "set_pixiv_token": set_pixiv_token,
+    "set_cache_ttl": set_cache_ttl,
+    "set_cache_redis": set_cache_redis,
 }

--- a/handlers/message_handlers/root.py
+++ b/handlers/message_handlers/root.py
@@ -12,11 +12,15 @@ from utils import is_group_type
 from .set_backblaze_appid import set_backblaze_appid
 from .set_user_nickname import set_user_nickname
 from .set_pixiv_token import set_pixiv_token
+from .set_cache_ttl import set_cache_ttl
+from .set_cache_redis import set_cache_redis
 
 _MESSAGE_HANDLERS = {
     "set_backblaze_appid": set_backblaze_appid,
     "set_user_nickname": set_user_nickname,
     "set_pixiv_token": set_pixiv_token,
+    "set_cache_ttl": set_cache_ttl,
+    "set_cache_redis": set_cache_redis,
 }
 
 

--- a/handlers/message_handlers/set_cache_redis.py
+++ b/handlers/message_handlers/set_cache_redis.py
@@ -1,0 +1,62 @@
+"""Message handler for updating Redis cache connection via chat."""
+
+from __future__ import annotations
+
+import logging
+
+from telegram import Update
+from telegram.error import TelegramError
+from telegram.ext import ContextTypes
+
+from handlers.callback_handlers.conf_handlers.bot.panel import refresh_bot_config_panel
+from registries import active_message_handler_registry, config_registry
+from services.telegram_cache import telegram_cache_manager
+
+logger = logging.getLogger(__name__)
+
+_HANDLER_PREFIX = "set_cache_redis"
+
+
+async def set_cache_redis(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    message = update.effective_message
+    user = update.effective_user
+
+    if message is None or user is None or not message.text:
+        return
+
+    handler_key = await active_message_handler_registry.get(user.id)
+    if not handler_key or not handler_key.startswith(_HANDLER_PREFIX):
+        return
+
+    _, _, metadata = handler_key.partition(":")
+    try:
+        panel_message_id = int(metadata)
+    except (TypeError, ValueError):
+        logger.warning("Cache redis handler metadata missing for user %s", user.id)
+        await active_message_handler_registry.delete(user_id=user.id)
+        return
+
+    submitted = message.text.strip()
+    normalized = submitted if submitted != "-" else ""
+
+    try:
+        await context.bot.delete_message(chat_id=message.chat_id, message_id=message.id)
+    except TelegramError:
+        logger.debug("Failed to delete redis command message for user %s", user.id)
+
+    await config_registry.set_telegram_cache_redis_url(normalized or None)
+    await telegram_cache_manager.reset()
+    await active_message_handler_registry.delete(user_id=user.id)
+
+    await refresh_bot_config_panel(
+        context,
+        chat_id=message.chat_id,
+        message_id=panel_message_id,
+    )
+
+    if normalized:
+        feedback = "已更新 Redis 地址"
+    else:
+        feedback = "已清除 Redis 地址"
+
+    await context.bot.send_message(chat_id=message.chat_id, text=feedback)

--- a/handlers/message_handlers/set_cache_ttl.py
+++ b/handlers/message_handlers/set_cache_ttl.py
@@ -1,0 +1,73 @@
+"""Message handler for updating Telegram cache TTL via chat."""
+
+from __future__ import annotations
+
+import logging
+
+from telegram import Update
+from telegram.error import TelegramError
+from telegram.ext import ContextTypes
+
+from handlers.callback_handlers.conf_handlers.bot.panel import refresh_bot_config_panel
+from registries import active_message_handler_registry, config_registry
+from services.telegram_cache import telegram_cache_manager
+
+logger = logging.getLogger(__name__)
+
+_HANDLER_PREFIX = "set_cache_ttl"
+_MIN_TTL = 30
+
+
+async def set_cache_ttl(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    message = update.effective_message
+    user = update.effective_user
+
+    if message is None or user is None or not message.text:
+        return
+
+    handler_key = await active_message_handler_registry.get(user.id)
+    if not handler_key or not handler_key.startswith(_HANDLER_PREFIX):
+        return
+
+    _, _, metadata = handler_key.partition(":")
+    try:
+        panel_message_id = int(metadata)
+    except (TypeError, ValueError):
+        logger.warning("Cache TTL handler metadata missing for user %s", user.id)
+        await active_message_handler_registry.delete(user_id=user.id)
+        return
+
+    submitted = message.text.strip()
+
+    try:
+        await context.bot.delete_message(chat_id=message.chat_id, message_id=message.id)
+    except TelegramError:
+        logger.debug("Failed to delete TTL command message for user %s", user.id)
+
+    try:
+        ttl_seconds = int(submitted)
+    except ValueError:
+        await context.bot.send_message(chat_id=message.chat_id, text="请输入有效的数字")
+        return
+
+    if ttl_seconds < _MIN_TTL:
+        await context.bot.send_message(
+            chat_id=message.chat_id,
+            text=f"TTL 必须大于等于 {_MIN_TTL} 秒",
+        )
+        return
+
+    await config_registry.set_telegram_cache_ttl(ttl_seconds)
+    await telegram_cache_manager.reset()
+    await active_message_handler_registry.delete(user_id=user.id)
+
+    await refresh_bot_config_panel(
+        context,
+        chat_id=message.chat_id,
+        message_id=panel_message_id,
+    )
+
+    await context.bot.send_message(
+        chat_id=message.chat_id,
+        text=f"缓存 TTL 已更新为 {ttl_seconds} 秒",
+    )

--- a/messase_generator/bot_admin.py
+++ b/messase_generator/bot_admin.py
@@ -77,6 +77,10 @@ async def bot_admin(page: int = 1) -> BotAdmin:
     pixiv_configured = any(token.token for token in pixiv_tokens)
     pixiv_enabled = any(token.enable for token in pixiv_tokens)
 
+    cache_config = await config_registry.get_telegram_cache_config()
+    cache_backend_label = "内存" if cache_config.backend == "memory" else "Redis"
+    cache_redis = cache_config.redis_url or "未配置"
+
     lines = [
         "机器人配置面板",
         "",
@@ -94,6 +98,11 @@ async def bot_admin(page: int = 1) -> BotAdmin:
         f"- 配置数量: {len(pixiv_tokens)}",
         f"- 已启用: {pixiv_enabled and '是' or '否'}",
         f"- 可用: {pixiv_configured and '是' or '否'}",
+        "",
+        "Telegram 缓存:",
+        f"- 后端: {cache_backend_label}",
+        f"- TTL: {cache_config.ttl_seconds} 秒",
+        f"- Redis 地址: {cache_redis}",
     ]
 
     text = "\n".join(_md(line) for line in lines)
@@ -121,6 +130,12 @@ async def bot_admin(page: int = 1) -> BotAdmin:
             InlineKeyboardButton(
                 "配置 Pixiv API",
                 callback_data="conf:bot:pixiv:menu",
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "缓存设置",
+                callback_data="conf:bot:cache:menu",
             )
         ],
         [InlineKeyboardButton("刷新", callback_data="conf:bot:panel:refresh")],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ aiorwlock = "1.5.0"
 pillow = "11.1.0"
 pixivpy3 = "3.7.5"
 b2sdk = "2.8.0"
+redis = "5.2.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ aiorwlock==1.5.0
 pillow==11.1.0
 pixivpy3==3.7.5
 b2sdk==2.8.0
+redis==5.2.1

--- a/services/telegram_cache.py
+++ b/services/telegram_cache.py
@@ -1,0 +1,230 @@
+"""Caching helpers for expensive Telegram Bot API calls."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import pickle
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Protocol
+
+from telegram import Bot
+from telegram.error import TelegramError
+from telegram.ext import ContextTypes
+
+from registries import config_registry
+
+try:  # pragma: no cover - optional dependency
+    from redis.asyncio import Redis  # type: ignore
+except Exception:  # pragma: no cover - redis is optional
+    Redis = None
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CacheEntry:
+    """Value container persisted in cache backends."""
+
+    value: Any
+    expires_at: datetime
+    stored_at: datetime
+
+    def is_valid(self, *, now: datetime) -> bool:
+        return now <= self.expires_at
+
+
+class CacheBackend(Protocol):
+    async def get(self, key: str) -> CacheEntry | None:
+        ...
+
+    async def set(self, key: str, entry: CacheEntry, ttl: int) -> None:
+        ...
+
+    async def delete(self, key: str) -> None:
+        ...
+
+    async def close(self) -> None:
+        ...
+
+
+class InMemoryCacheBackend:
+    """A simple asyncio-safe in-memory cache backend."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, CacheEntry] = {}
+        self._lock = asyncio.Lock()
+
+    async def get(self, key: str) -> CacheEntry | None:
+        async with self._lock:
+            entry = self._data.get(key)
+            if entry is None:
+                return None
+            now = datetime.now(timezone.utc)
+            if entry.expires_at + timedelta(seconds=entry_ttl_leeway(entry)) < now:
+                # Entry is far beyond its TTL, remove it entirely.
+                self._data.pop(key, None)
+                return None
+            return entry
+
+    async def set(self, key: str, entry: CacheEntry, ttl: int) -> None:
+        async with self._lock:
+            self._data[key] = entry
+
+    async def delete(self, key: str) -> None:
+        async with self._lock:
+            self._data.pop(key, None)
+
+    async def close(self) -> None:  # pragma: no cover - nothing to cleanup
+        async with self._lock:
+            self._data.clear()
+
+
+class RedisCacheBackend:
+    """Redis powered backend to share cache state across workers."""
+
+    def __init__(self, url: str) -> None:
+        if Redis is None:
+            raise RuntimeError("redis dependency is not installed")
+        if not url:
+            raise ValueError("Redis URL must be provided for redis cache backend")
+        self._redis = Redis.from_url(url, decode_responses=False)
+
+    async def get(self, key: str) -> CacheEntry | None:
+        payload = await self._redis.get(key)
+        if payload is None:
+            return None
+        try:
+            entry: CacheEntry = pickle.loads(payload)
+        except Exception:  # pragma: no cover - corrupted payload
+            logger.exception("Failed to deserialize cache entry for key %s", key)
+            await self._redis.delete(key)
+            return None
+        return entry
+
+    async def set(self, key: str, entry: CacheEntry, ttl: int) -> None:
+        payload = pickle.dumps(entry)
+        ttl_with_slack = max(ttl * 3, ttl + 300)
+        await self._redis.set(key, payload, ex=ttl_with_slack)
+
+    async def delete(self, key: str) -> None:
+        await self._redis.delete(key)
+
+    async def close(self) -> None:
+        await self._redis.close()
+
+
+def entry_ttl_leeway(entry: CacheEntry) -> int:
+    """Provide additional time-to-live slack for cache eviction checks."""
+
+    ttl = int((entry.expires_at - entry.stored_at).total_seconds())
+    return max(ttl, 300)
+
+
+class TelegramCacheManager:
+    """Manage cache backend instantiation based on dynamic configuration."""
+
+    def __init__(self) -> None:
+        self._backend: CacheBackend | None = None
+        self._config: config_registry.TelegramCacheConfig | None = None
+        self._lock = asyncio.Lock()
+
+    async def _ensure_backend(self) -> tuple[CacheBackend, config_registry.TelegramCacheConfig]:
+        config = await config_registry.get_telegram_cache_config()
+        async with self._lock:
+            if self._backend is not None and self._config == config:
+                return self._backend, config
+
+            if self._backend is not None:
+                try:
+                    await self._backend.close()
+                except Exception:  # pragma: no cover - best effort cleanup
+                    logger.exception("Failed to close previous cache backend")
+
+            backend = await self._build_backend(config)
+            self._backend = backend
+            self._config = config
+            return backend, config
+
+    async def _build_backend(self, config: config_registry.TelegramCacheConfig) -> CacheBackend:
+        backend_name = config.backend
+        if backend_name == "redis":
+            try:
+                return RedisCacheBackend(config.redis_url or "")
+            except Exception as exc:
+                logger.warning(
+                    "Falling back to in-memory cache backend because Redis backend failed: %s",
+                    exc,
+                )
+        return InMemoryCacheBackend()
+
+    async def reset(self) -> None:
+        async with self._lock:
+            if self._backend is not None:
+                try:
+                    await self._backend.close()
+                except Exception:  # pragma: no cover - best effort cleanup
+                    logger.exception("Failed to close cache backend during reset")
+            self._backend = None
+            self._config = None
+
+    async def get_backend(self) -> tuple[CacheBackend, config_registry.TelegramCacheConfig]:
+        return await self._ensure_backend()
+
+
+telegram_cache_manager = TelegramCacheManager()
+
+
+def _build_admin_cache_key(chat_id: int) -> str:
+    return f"telegram:chat:{chat_id}:admins"
+
+
+async def get_cached_admin_ids(
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+) -> list[int] | None:
+    """Return administrator IDs using the configured cache backend."""
+
+    bot: Bot | None = context.bot
+    if bot is None:
+        logger.debug("Telegram context bot missing while resolving admin cache")
+        return None
+
+    backend, config = await telegram_cache_manager.get_backend()
+
+    key = _build_admin_cache_key(chat_id)
+    entry = await backend.get(key)
+    now = datetime.now(timezone.utc)
+
+    if entry and entry.is_valid(now=now):
+        return list(entry.value)
+
+    try:
+        admins = await bot.get_chat_administrators(chat_id)
+    except TelegramError as exc:
+        if entry:
+            logger.debug(
+                "Using stale cached admin list for chat %s due to Telegram error: %s",
+                chat_id,
+                exc,
+            )
+            return list(entry.value)
+        logger.warning("Failed to fetch administrators for chat %s: %s", chat_id, exc)
+        return None
+
+    admin_ids = [member.user.id for member in admins if member.user]
+
+    ttl_seconds = max(config.ttl_seconds, 30)
+    expires_at = now + timedelta(seconds=ttl_seconds)
+    new_entry = CacheEntry(value=admin_ids, expires_at=expires_at, stored_at=now)
+    await backend.set(key, new_entry, ttl_seconds)
+
+    return admin_ids
+
+
+async def invalidate_chat_admins(chat_id: int) -> None:
+    """Invalidate cached administrator IDs for the specified chat."""
+
+    backend, _ = await telegram_cache_manager.get_backend()
+    await backend.delete(_build_admin_cache_key(chat_id))


### PR DESCRIPTION
## Summary
- add a shared Telegram cache service that backs get_chat_administrators with memory or Redis backends
- extend the admin configuration panel and callback handlers to manage cache backend, TTL, and Redis connection
- add chat-driven message handlers for cache settings and declare the redis dependency

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dc37772474832fa4f251d06d39a1c5