### PR TITLE
feat: 支持 Pixiv 多刷新令牌负载均衡

### DIFF
--- a/handlers/message_handlers/set_pixiv_token.py
+++ b/handlers/message_handlers/set_pixiv_token.py
@@ -1,4 +1,4 @@
-"""Message handler that stores Pixiv refresh tokens submitted via chat."""
+﻿"""Message handler that stores Pixiv refresh tokens submitted via chat."""
 
 from __future__ import annotations
 
@@ -8,12 +8,20 @@ from telegram import Update
 from telegram.ext import ContextTypes
 
 from registries import active_message_handler_registry, config_registry
+from services import pixiv
 
 from handlers.callback_handlers.conf_handlers.bot.panel import refresh_bot_config_panel
 
 logger = logging.getLogger(__name__)
 
 _HANDLER_PREFIX = "set_pixiv_token"
+_CANCEL_TOKEN = "-"
+
+
+async def _reload_pixiv_state() -> None:
+    await pixiv.read_token_from_config()
+    if pixiv.enabled:
+        await pixiv.token_refresh(force=True)
 
 
 async def set_pixiv_token(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -27,28 +35,49 @@ async def set_pixiv_token(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     if not handler_key or not handler_key.startswith(_HANDLER_PREFIX):
         return
 
-    _, _, metadata = handler_key.partition(":")
-    if not metadata:
-        logger.warning("Pixiv token handler metadata missing for user %s", user.id)
+    parts = handler_key.split(":", 3)
+    if len(parts) < 4:
+        logger.warning("Pixiv token handler metadata malformed for user %s: %s", user.id, handler_key)
         await active_message_handler_registry.delete(user_id=user.id)
         return
 
+    _, mode, panel_message_id_text, token_id_text = parts
+
     try:
-        panel_message_id = int(metadata)
+        panel_message_id = int(panel_message_id_text)
     except ValueError:
-        logger.warning("Invalid Pixiv handler metadata '%s' for user %s", metadata, user.id)
+        logger.warning("Invalid panel message id '%s' for user %s", panel_message_id_text, user.id)
         await active_message_handler_registry.delete(user_id=user.id)
         return
+
+    token_id = 0
+    if token_id_text and token_id_text != "0":
+        try:
+            token_id = int(token_id_text)
+        except ValueError:
+            logger.warning("Invalid token id '%s' for user %s", token_id_text, user.id)
+            await active_message_handler_registry.delete(user_id=user.id)
+            return
 
     submitted = message.text.strip()
 
-    if submitted == "-":
-        await config_registry.set_pixiv_token(None)
-        await config_registry.set_pixiv_token_enabled(False)
-        feedback = "已清除 Pixiv Refresh Token，并禁用 Pixiv 功能"
+    if submitted == _CANCEL_TOKEN:
+        feedback = "已取消 Pixiv Token 操作"
     else:
-        await config_registry.set_pixiv_token(submitted)
-        feedback = "已更新 Pixiv Refresh Token"
+        try:
+            if mode == "add":
+                await config_registry.add_pixiv_token(submitted, enabled=True)
+                feedback = "已添加新的 Pixiv Refresh Token"
+            elif mode == "update" and token_id > 0:
+                await config_registry.update_pixiv_token(token_id, submitted)
+                feedback = "已更新 Pixiv Refresh Token"
+            else:
+                feedback = "未识别的 Pixiv Token 操作"
+                logger.warning("Unknown Pixiv token mode '%s' for user %s", mode, user.id)
+            await _reload_pixiv_state()
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Failed to process Pixiv token submission for user %s", user.id)
+            feedback = f"操作失败：{exc}"
 
     await active_message_handler_registry.delete(user_id=user.id)
 

--- a/main.py
+++ b/main.py
@@ -49,7 +49,7 @@ async def lifespan(app: FastAPI):
     await tg_bot.config()
     await pixiv.read_token_from_config()
     if pixiv.enabled:
-        pixiv.token_refresh()
+        await pixiv.token_refresh()
     else:
         logger.warning("Pixiv features disabled due to missing token")
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,5 +1,6 @@
-from .base import Base
+﻿from .base import Base
 from .configs import Config
+from .pixiv_tokens import PixivToken
 from .groups import Group
 from .users import User
 from .active_message_handler import ActiveMessageHandler

--- a/models/pixiv_tokens.py
+++ b/models/pixiv_tokens.py
@@ -1,0 +1,12 @@
+﻿from sqlalchemy import Boolean, Column, Integer, String
+
+from configs import config as file_config
+
+from .base import Base
+
+
+class PixivToken(Base):
+    __tablename__ = f"{file_config.db_prefix}pixiv_tokens"
+    id = Column(Integer, primary_key=True, autoincrement=True, comment="Pixiv Token ID")
+    refresh_token = Column(String(512), nullable=False, comment="Pixiv Refresh Token")
+    enabled = Column(Boolean, default=True, nullable=False, comment="Token enabled flag")

--- a/services/pixiv_service.py
+++ b/services/pixiv_service.py
@@ -1,63 +1,175 @@
+﻿import asyncio
 import logging
 import time
+from dataclasses import dataclass, field
 
-from pixivpy3 import *
+from pixivpy3 import AppPixivAPI
+
+try:
+    from pixivpy3 import PixivError  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover
+    class PixivError(Exception):
+        """Fallback exception type when pixivpy3 does not expose PixivError."""
+        pass
+
 from registries import config_registry
-
 from models import Illustration, build_illust_from_api_dict
 
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class _TokenState:
+    id: int
+    refresh_token: str
+    enabled: bool
+    client: AppPixivAPI = field(default_factory=AppPixivAPI)
+    valid_until: int = 0
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    last_error: str | None = None
+
+
 class PixivService:
-    def __init__(self):
-        self.valid_until: int | None = None
-        self.token: str | None = None
+    def __init__(self) -> None:
+        self._tokens: list[_TokenState] = []
+        self._next_index: int = 0
+        self._state_lock = asyncio.Lock()
         self.enabled: bool = False
-        self.api = AppPixivAPI()
 
-    async def read_token_from_config(self):
-        tokens = await config_registry.get_pixiv_tokens()
-        if len(tokens) == 0:
-            logger.warning("No Pixiv token configured, Pixiv features disabled")
-            self.token = None
-            self.valid_until = None
-            self.enabled = False
-            return
-        if len(tokens) > 1:
-            logger.warning("More than one Pixiv token found, using the first one")
-        self.token = tokens[0].token
-        self.valid_until = 0
-        self.enabled = False
+    async def read_token_from_config(self) -> None:
+        records = await config_registry.get_pixiv_tokens()
+        tokens: list[_TokenState] = []
 
-    def token_refresh(self, force: bool = False):
-        if not self.enabled or self.token is None:
-            logger.debug("Pixiv token refresh skipped because the feature is disabled")
-            return
-        if not force and self.valid_until > int(time.time()):
-            return
-        response = self.api.auth(refresh_token=self.token)
-        self.valid_until = int(time.time()) + int(response["expires_in"]) - 60
-        logger.info("已刷新PixivAccessToken")
-        return
+        for record in records:
+            if record.id is None:
+                continue
+            refresh_token = (record.token or "").strip()
+            if not refresh_token:
+                continue
+            tokens.append(
+                _TokenState(
+                    id=record.id,
+                    refresh_token=refresh_token,
+                    enabled=record.enable,
+                )
+            )
 
-    async def get_raw(self, pixiv_id: int):
-        if not self.enabled:
-            raise RuntimeError("Pixiv features are disabled")
-        self.token_refresh()
-        response = self.api.illust_detail(pixiv_id)
-        if response.get("error") is not None:
-            self.token_refresh(force=True)
-        response = self.api.illust_detail(pixiv_id)
-        return response
+        async with self._state_lock:
+            self._tokens = tokens
+            self._next_index = 0
+            self.enabled = any(token.enabled for token in tokens)
+
+        if self.enabled:
+            total = len(tokens)
+            active = sum(1 for token in tokens if token.enabled)
+            logger.info("Loaded %s Pixiv refresh tokens (%s enabled)", total, active)
+        else:
+            logger.warning("Pixiv features disabled due to missing enabled tokens")
+
+    async def token_refresh(self, force: bool = False) -> None:
+        async with self._state_lock:
+            tokens = [token for token in self._tokens if token.enabled]
+
+        if not tokens:
+            logger.debug("Pixiv token refresh skipped because no enabled tokens")
+            return
+
+        for token in tokens:
+            try:
+                await self._refresh_token(token, force=force)
+            except Exception as exc:
+                logger.warning("Failed to refresh Pixiv token %s: %s", token.id, exc)
+
+    async def _refresh_token(self, token: _TokenState, *, force: bool = False) -> None:
+        async with token.lock:
+            now = int(time.time())
+            if not force and token.valid_until > now:
+                return
+
+            try:
+                response = token.client.auth(refresh_token=token.refresh_token)
+            except PixivError as exc:
+                token.valid_until = 0
+                token.last_error = str(exc)
+                logger.warning("Pixiv authentication failed for token %s: %s", token.id, exc)
+                raise
+            except Exception as exc:
+                token.valid_until = 0
+                token.last_error = str(exc)
+                logger.warning("Unexpected Pixiv auth error for token %s: %s", token.id, exc)
+                raise
+
+            expires_in = int(response.get("expires_in", 0) or 0)
+            token.valid_until = now + max(expires_in - 60, 60)
+            token.last_error = None
+            logger.debug("Refreshed Pixiv token %s, valid for %s seconds", token.id, expires_in)
+
+    async def _ordered_tokens(self) -> list[_TokenState]:
+        async with self._state_lock:
+            active = [token for token in self._tokens if token.enabled]
+            self.enabled = bool(active)
+            if not active:
+                raise RuntimeError("Pixiv features are disabled")
+
+            start = self._next_index % len(active)
+            order = active[start:] + active[:start]
+            self._next_index = (self._next_index + 1) % len(active)
+
+        return order
+
+    async def _fetch_illust_detail(self, pixiv_id: int) -> dict:
+        candidates = await self._ordered_tokens()
+        last_error: Exception | None = None
+
+        for token in candidates:
+            try:
+                await self._refresh_token(token)
+            except Exception as exc:
+                last_error = exc
+                continue
+
+            try:
+                response = token.client.illust_detail(pixiv_id)
+            except PixivError as exc:
+                token.valid_until = 0
+                token.last_error = str(exc)
+                logger.warning("Pixiv API error for token %s: %s", token.id, exc)
+                last_error = exc
+                continue
+            except Exception as exc:
+                token.last_error = str(exc)
+                logger.warning("Unexpected Pixiv client error for token %s: %s", token.id, exc)
+                last_error = exc
+                continue
+
+            if response.get("error"):
+                logger.warning("Pixiv API responded with error for token %s: %s", token.id, response["error"])
+                try:
+                    await self._refresh_token(token, force=True)
+                    response = token.client.illust_detail(pixiv_id)
+                except Exception as exc:
+                    token.last_error = str(exc)
+                    last_error = exc
+                    continue
+                if response.get("error"):
+                    token.last_error = str(response["error"])
+                    last_error = RuntimeError(str(response["error"]))
+                    continue
+
+            token.last_error = None
+            return response
+
+        raise RuntimeError("All Pixiv tokens failed to fetch illust detail") from last_error
+
+    async def get_raw(self, pixiv_id: int) -> dict:
+        return await self._fetch_illust_detail(pixiv_id)
 
     async def get_illust_info_by_pixiv_id(self, pixiv_id: int) -> Illustration:
-        if not self.enabled:
-            raise RuntimeError("Pixiv features are disabled")
-        self.token_refresh()
-        illust_info_dict: dict = self.api.illust_detail(pixiv_id)['illust']
-        illust = build_illust_from_api_dict(illust_info_dict)
-        return illust
+        response = await self._fetch_illust_detail(pixiv_id)
+        illust_data = response.get("illust")
+        if not isinstance(illust_data, dict):
+            raise RuntimeError("Pixiv response missing illust data")
+        return build_illust_from_api_dict(illust_data)
 
 
 pixiv = PixivService()


### PR DESCRIPTION
- 新增 PixivToken 模型及配置仓库 CRUD，兼容迁移旧配置
- 重写 PixivService 轮询刷新与失效回退逻辑
- 更新管理端交互与消息处理以操作多枚刷新令牌