### PR TITLE
feat(bot): 实现 Telegram 机器人命令注册与管理面板增强功能

### DIFF
--- a/handlers/callback_handlers/conf_handlers/bot/bot_conf_handler.py
+++ b/handlers/callback_handlers/conf_handlers/bot/bot_conf_handler.py
@@ -1,11 +1,24 @@
-from telegram import Update
+﻿from telegram import Update
 from telegram.ext import ContextTypes
 
+from handlers.callback_handlers.panel_utils import close_panel
+
+from .cache import handle_cache
 from .feature_flags import handle_feature_flag
 from .panel import refresh_bot_config_panel
-from .storage import handle_storage
 from .pixiv import handle_pixiv
-from .cache import handle_cache
+from .storage import handle_storage
+
+
+def _parse_command_message_id(cmd_parts: list[str]) -> int | None:
+    if len(cmd_parts) <= 2:
+        return None
+    raw_value = cmd_parts[2]
+    try:
+        return int(raw_value)
+    except (TypeError, ValueError):
+        return None
+
 
 handler_map = {
     "feature": handle_feature_flag,
@@ -22,14 +35,26 @@ async def bot_conf_handler_func(update: Update, context: ContextTypes.DEFAULT_TY
 
     section = cmd[0]
 
-    if section == "panel" and len(cmd) > 1 and cmd[1] == "refresh":
-        await refresh_bot_config_panel(
-            context,
-            chat_id=update.effective_chat.id,
-            message_id=update.effective_message.message_id,
-        )
-        await query.answer("已刷新")
-        return
+    if section == "panel" and len(cmd) > 1:
+        action = cmd[1]
+        command_message_id = _parse_command_message_id(cmd)
+        if action == "refresh":
+            await refresh_bot_config_panel(
+                context,
+                chat_id=update.effective_chat.id,
+                message_id=update.effective_message.message_id,
+                command_message_id=command_message_id,
+            )
+            await query.answer("已刷新")
+            return
+        if action == "close":
+            await close_panel(
+                update,
+                context,
+                user_id=update.effective_user.id,
+                command_message_id=command_message_id,
+            )
+            return
 
     handler = handler_map.get(section)
     if handler is None:

--- a/handlers/callback_handlers/conf_handlers/bot/feature_flags.py
+++ b/handlers/callback_handlers/conf_handlers/bot/feature_flags.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from handlers.callback_handlers.panel_utils import get_panel_command_message_id
 from registries import config_registry
 
 from .panel import refresh_bot_config_panel
@@ -56,8 +57,12 @@ async def handle_feature_flag(update: Update, context: ContextTypes.DEFAULT_TYPE
     label, enabled_text, disabled_text = _MUTABLE_FLAGS[key]
     await query.answer(f"{label} {enabled_text if new_value else disabled_text}")
 
+    panel_message_id = update.effective_message.message_id
+    command_message_id = get_panel_command_message_id(context, panel_message_id)
+
     await refresh_bot_config_panel(
         context,
         chat_id=update.effective_chat.id,
-        message_id=update.effective_message.message_id,
+        message_id=panel_message_id,
+        command_message_id=command_message_id,
     )

--- a/handlers/callback_handlers/conf_handlers/bot/panel.py
+++ b/handlers/callback_handlers/conf_handlers/bot/panel.py
@@ -8,6 +8,7 @@ from telegram import InlineKeyboardMarkup
 from telegram.error import TelegramError
 from telegram.ext import ContextTypes
 
+from handlers.callback_handlers.panel_utils import get_panel_command_message_id, register_panel
 import messase_generator
 
 logger = logging.getLogger(__name__)
@@ -18,8 +19,11 @@ async def refresh_bot_config_panel(
     *,
     chat_id: int,
     message_id: int,
+    command_message_id: int | None = None,
 ) -> None:
-    panel = await messase_generator.bot_admin()
+    if command_message_id is None:
+        command_message_id = get_panel_command_message_id(context, message_id)
+    panel = await messase_generator.bot_admin(command_message_id=command_message_id)
 
     try:
         await context.bot.edit_message_text(
@@ -32,6 +36,7 @@ async def refresh_bot_config_panel(
             message_id=message_id,
             reply_markup=InlineKeyboardMarkup(panel.keyboard),
         )
+        register_panel(context, message_id, command_message_id)
     except TelegramError as exc:
         logger.warning(
             "Failed to refresh bot config panel for chat %s message %s: %s",

--- a/handlers/callback_handlers/conf_handlers/bot/pixiv.py
+++ b/handlers/callback_handlers/conf_handlers/bot/pixiv.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
 
+from handlers.callback_handlers.panel_utils import build_callback_data, get_panel_command_message_id
 from registries import active_message_handler_registry, config_registry
 from services import pixiv
 
@@ -30,7 +31,9 @@ def _mask_token_value(token: str) -> str:
     return f"{text[:3]}…{text[-4:]}"
 
 
-def _build_main_menu(tokens: list[config_registry.Token]) -> InlineKeyboardMarkup:
+def _build_main_menu(
+    tokens: list[config_registry.Token], *, command_message_id: int | None
+) -> InlineKeyboardMarkup:
     rows: list[list[InlineKeyboardButton]] = []
 
     rows.append(
@@ -57,7 +60,7 @@ def _build_main_menu(tokens: list[config_registry.Token]) -> InlineKeyboardMarku
             [InlineKeyboardButton("清除全部", callback_data="conf:bot:pixiv:delete_all")]
         )
 
-    rows.append([InlineKeyboardButton("返回", callback_data="conf:bot:panel:refresh")])
+    rows.append([InlineKeyboardButton("返回", callback_data=build_callback_data("conf:bot:panel:refresh", command_message_id))])
     return InlineKeyboardMarkup(rows)
 
 
@@ -93,13 +96,14 @@ async def handle_pixiv(update: Update, context: ContextTypes.DEFAULT_TYPE, cmd: 
         return
 
     panel_message_id = message.message_id
+    command_message_id = get_panel_command_message_id(context, panel_message_id)
 
     if action == "menu":
         tokens = await config_registry.get_pixiv_tokens()
         await context.bot.edit_message_reply_markup(
             chat_id=chat.id,
             message_id=panel_message_id,
-            reply_markup=_build_main_menu(tokens),
+            reply_markup=_build_main_menu(tokens, command_message_id=command_message_id),
         )
         await query.answer("已打开 Pixiv 配置")
         return
@@ -165,9 +169,14 @@ async def handle_pixiv(update: Update, context: ContextTypes.DEFAULT_TYPE, cmd: 
         await context.bot.edit_message_reply_markup(
             chat_id=chat.id,
             message_id=panel_message_id,
-            reply_markup=_build_main_menu(updated_tokens),
+            reply_markup=_build_main_menu(updated_tokens, command_message_id=command_message_id),
         )
-        await refresh_bot_config_panel(context, chat_id=chat.id, message_id=panel_message_id)
+        await refresh_bot_config_panel(
+            context,
+            chat_id=chat.id,
+            message_id=panel_message_id,
+            command_message_id=command_message_id,
+        )
         await query.answer("已更新 Token 状态")
         return
 
@@ -184,9 +193,14 @@ async def handle_pixiv(update: Update, context: ContextTypes.DEFAULT_TYPE, cmd: 
         await context.bot.edit_message_reply_markup(
             chat_id=chat.id,
             message_id=panel_message_id,
-            reply_markup=_build_main_menu(updated_tokens),
+            reply_markup=_build_main_menu(updated_tokens, command_message_id=command_message_id),
         )
-        await refresh_bot_config_panel(context, chat_id=chat.id, message_id=panel_message_id)
+        await refresh_bot_config_panel(
+            context,
+            chat_id=chat.id,
+            message_id=panel_message_id,
+            command_message_id=command_message_id,
+        )
         await query.answer("已删除 Token")
         return
 
@@ -197,9 +211,14 @@ async def handle_pixiv(update: Update, context: ContextTypes.DEFAULT_TYPE, cmd: 
         await context.bot.edit_message_reply_markup(
             chat_id=chat.id,
             message_id=panel_message_id,
-            reply_markup=_build_main_menu(updated_tokens),
+            reply_markup=_build_main_menu(updated_tokens, command_message_id=command_message_id),
         )
-        await refresh_bot_config_panel(context, chat_id=chat.id, message_id=panel_message_id)
+        await refresh_bot_config_panel(
+            context,
+            chat_id=chat.id,
+            message_id=panel_message_id,
+            command_message_id=command_message_id,
+        )
         await query.answer("已启用全部 Token")
         return
 
@@ -210,9 +229,14 @@ async def handle_pixiv(update: Update, context: ContextTypes.DEFAULT_TYPE, cmd: 
         await context.bot.edit_message_reply_markup(
             chat_id=chat.id,
             message_id=panel_message_id,
-            reply_markup=_build_main_menu(updated_tokens),
+            reply_markup=_build_main_menu(updated_tokens, command_message_id=command_message_id),
         )
-        await refresh_bot_config_panel(context, chat_id=chat.id, message_id=panel_message_id)
+        await refresh_bot_config_panel(
+            context,
+            chat_id=chat.id,
+            message_id=panel_message_id,
+            command_message_id=command_message_id,
+        )
         await query.answer("已禁用全部 Token")
         return
 
@@ -223,9 +247,14 @@ async def handle_pixiv(update: Update, context: ContextTypes.DEFAULT_TYPE, cmd: 
         await context.bot.edit_message_reply_markup(
             chat_id=chat.id,
             message_id=panel_message_id,
-            reply_markup=_build_main_menu(updated_tokens),
+            reply_markup=_build_main_menu(updated_tokens, command_message_id=command_message_id),
         )
-        await refresh_bot_config_panel(context, chat_id=chat.id, message_id=panel_message_id)
+        await refresh_bot_config_panel(
+            context,
+            chat_id=chat.id,
+            message_id=panel_message_id,
+            command_message_id=command_message_id,
+        )
         await query.answer("已清除全部 Token")
         return
 

--- a/handlers/callback_handlers/conf_handlers/user_conf_handlers/panel.py
+++ b/handlers/callback_handlers/conf_handlers/user_conf_handlers/panel.py
@@ -8,6 +8,7 @@ from telegram import InlineKeyboardMarkup
 from telegram.error import TelegramError
 from telegram.ext import ContextTypes
 
+from handlers.callback_handlers.panel_utils import get_panel_command_message_id, register_panel
 import messase_generator
 from registries import user_registry
 
@@ -20,11 +21,14 @@ async def refresh_user_config_panel(
     chat_id: int,
     message_id: int,
     user_id: int,
+    command_message_id: int | None = None,
 ) -> None:
     """Re-render the user configuration panel in place."""
 
     user = await user_registry.get_user_by_id(user_id)
-    panel = await messase_generator.config_user(user=user)
+    if command_message_id is None:
+        command_message_id = get_panel_command_message_id(context, message_id)
+    panel = await messase_generator.config_user(user=user, command_message_id=command_message_id)
 
     try:
         await context.bot.edit_message_text(
@@ -37,6 +41,7 @@ async def refresh_user_config_panel(
             message_id=message_id,
             reply_markup=InlineKeyboardMarkup(panel.keyboard),
         )
+        register_panel(context, message_id, command_message_id)
     except TelegramError as exc:
         logger.warning(
             "Failed to refresh user config panel for chat %s message %s: %s",

--- a/handlers/callback_handlers/conf_handlers/user_conf_handlers/user_conf_handler.py
+++ b/handlers/callback_handlers/conf_handlers/user_conf_handlers/user_conf_handler.py
@@ -1,6 +1,7 @@
-from telegram import Update
+﻿from telegram import Update
 from telegram.ext import ContextTypes
 
+from handlers.callback_handlers.panel_utils import close_panel
 from registries import active_message_handler_registry
 
 from .chat_toggle import handle_chat_toggle
@@ -8,6 +9,17 @@ from .nick import handle_nick
 from .panel import refresh_user_config_panel
 from .sanity import handle_sanity
 from .switch_r18g import switch_r18g
+
+
+def _parse_command_message_id(cmd_parts: list[str]) -> int | None:
+    if len(cmd_parts) <= 2:
+        return None
+    value = cmd_parts[2]
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
 
 handler_map = {
     "chat": handle_chat_toggle,
@@ -24,16 +36,28 @@ async def user_conf_handler_func(update: Update, context: ContextTypes.DEFAULT_T
 
     section = cmd[0]
 
-    if section == "panel" and len(cmd) > 1 and cmd[1] == "refresh":
-        await active_message_handler_registry.delete(user_id=update.effective_user.id)
-        await refresh_user_config_panel(
-            context,
-            chat_id=update.effective_chat.id,
-            message_id=update.effective_message.message_id,
-            user_id=update.effective_user.id,
-        )
-        await query.answer("已刷新")
-        return
+    if section == "panel" and len(cmd) > 1:
+        action = cmd[1]
+        command_message_id = _parse_command_message_id(cmd)
+        if action == "refresh":
+            await active_message_handler_registry.delete(user_id=update.effective_user.id)
+            await refresh_user_config_panel(
+                context,
+                chat_id=update.effective_chat.id,
+                message_id=update.effective_message.message_id,
+                user_id=update.effective_user.id,
+                command_message_id=command_message_id,
+            )
+            await query.answer("已刷新")
+            return
+        if action == "close":
+            await close_panel(
+                update,
+                context,
+                user_id=update.effective_user.id,
+                command_message_id=command_message_id,
+            )
+            return
 
     handler = handler_map.get(section)
     if handler is None:

--- a/handlers/callback_handlers/panel_utils.py
+++ b/handlers/callback_handlers/panel_utils.py
@@ -1,0 +1,116 @@
+﻿"""Utilities for tracking inline panel state and handling closures."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from telegram import Update
+from telegram.error import TelegramError
+from telegram.ext import ContextTypes
+
+from registries import active_message_handler_registry
+
+logger = logging.getLogger(__name__)
+
+_PANEL_MAP_KEY = "__panel_command_map__"
+
+
+def build_callback_data(base: str, command_message_id: int | None) -> str:
+    """Append the originating command message ID to callback data when available."""
+
+    if command_message_id is None:
+        return base
+    return f"{base}:{command_message_id}"
+
+
+def register_panel(context: ContextTypes.DEFAULT_TYPE, panel_message_id: int, command_message_id: int | None) -> None:
+    """Store the originating command message for a rendered panel message."""
+
+    mapping = _ensure_panel_map(context)
+    mapping[panel_message_id] = command_message_id
+
+
+def unregister_panel(context: ContextTypes.DEFAULT_TYPE, panel_message_id: int) -> None:
+    mapping = context.chat_data.get(_PANEL_MAP_KEY)
+    if isinstance(mapping, dict):
+        mapping.pop(panel_message_id, None)
+
+
+def get_panel_command_message_id(
+    context: ContextTypes.DEFAULT_TYPE, panel_message_id: int
+) -> int | None:
+    mapping = context.chat_data.get(_PANEL_MAP_KEY)
+    if isinstance(mapping, dict):
+        command_message_id = mapping.get(panel_message_id)
+        if isinstance(command_message_id, int):
+            return command_message_id
+    return None
+
+
+def _ensure_panel_map(context: ContextTypes.DEFAULT_TYPE) -> dict[int, int | None]:
+    mapping = context.chat_data.get(_PANEL_MAP_KEY)
+    if not isinstance(mapping, dict):
+        mapping = {}
+        context.chat_data[_PANEL_MAP_KEY] = mapping
+    return mapping
+
+
+def _parse_command_id(command_message_id: int | None, context: ContextTypes.DEFAULT_TYPE, panel_message_id: int | None) -> int | None:
+    if command_message_id is not None:
+        return command_message_id
+    if panel_message_id is None:
+        return None
+    return get_panel_command_message_id(context, panel_message_id)
+
+
+async def close_panel(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    user_id: int | None = None,
+    command_message_id: int | None = None,
+    ack_text: str = "已关闭"
+) -> None:
+    """Close a configuration panel and delete its originating command message."""
+
+    query = update.callback_query
+    panel_message = update.effective_message
+    chat = update.effective_chat
+
+    panel_message_id = getattr(panel_message, "message_id", None)
+    resolved_command_id = _parse_command_id(command_message_id, context, panel_message_id)
+
+    if user_id is not None:
+        await active_message_handler_registry.delete(user_id=user_id)
+
+    if panel_message_id is not None:
+        unregister_panel(context, panel_message_id)
+
+    if chat is None:
+        if query is not None:
+            await query.answer(ack_text)
+        return
+
+    chat_id = chat.id
+
+    if panel_message_id is not None:
+        try:
+            await context.bot.delete_message(chat_id=chat_id, message_id=panel_message_id)
+        except TelegramError as exc:
+            logger.warning("Failed to delete panel message %s in chat %s: %s", panel_message_id, chat_id, exc)
+
+    if resolved_command_id is not None:
+        try:
+            await context.bot.delete_message(chat_id=chat_id, message_id=resolved_command_id)
+        except TelegramError as exc:
+            logger.warning(
+                "Failed to delete originating command message %s in chat %s: %s",
+                resolved_command_id,
+                chat_id,
+                exc,
+            )
+
+    if query is not None:
+        await query.answer(ack_text)
+

--- a/handlers/command_handlers/admin_handler.py
+++ b/handlers/command_handlers/admin_handler.py
@@ -7,6 +7,7 @@ from telegram.constants import ParseMode
 import messase_generator
 from utils import is_group_type, delete_messages
 from registries import user_registry, group_registry, engine
+from handlers.callback_handlers.panel_utils import register_panel
 from services.command_history import command_logger
 from handlers.registry import bot_handler
 
@@ -35,7 +36,9 @@ async def admin_handler_func(update: Update, context: ContextTypes.DEFAULT_TYPE)
             delay=10
         ))
         return
-    config = await messase_generator.bot_admin(page=1)
+    command_message = update.effective_message
+    command_message_id = getattr(command_message, "message_id", None)
+    config = await messase_generator.bot_admin(page=1, command_message_id=command_message_id)
 
     message: Message = await context.bot.send_message(
         chat_id=update.effective_chat.id,
@@ -43,5 +46,7 @@ async def admin_handler_func(update: Update, context: ContextTypes.DEFAULT_TYPE)
         reply_markup=InlineKeyboardMarkup(config.keyboard),
         parse_mode=ParseMode.MARKDOWN_V2
     )
+
+    register_panel(context, message.message_id, command_message_id)
     return
 

--- a/handlers/command_handlers/option_handler.py
+++ b/handlers/command_handlers/option_handler.py
@@ -5,6 +5,7 @@ from telegram import Update, Message, InlineKeyboardMarkup
 import messase_generator
 from utils import is_group_type, delete_messages
 from registries import user_registry, group_registry, engine
+from handlers.callback_handlers.panel_utils import register_panel
 from services.command_history import command_logger
 from handlers.registry import bot_handler
 
@@ -37,12 +38,16 @@ async def option_handler_func(update: Update, context) -> None:
             ))
             return
         return
-    config = await messase_generator.config_user(page=1, user=user)
+    command_message = update.effective_message
+    command_message_id = getattr(command_message, "message_id", None)
+    config = await messase_generator.config_user(page=1, user=user, command_message_id=command_message_id)
 
     message: Message = await context.bot.send_message(
         chat_id=update.effective_chat.id,
         text=config.text,
         reply_markup=InlineKeyboardMarkup(config.keyboard)
     )
+
+    register_panel(context, message.message_id, command_message_id)
     return
 

--- a/messase_generator/bot_admin.py
+++ b/messase_generator/bot_admin.py
@@ -45,6 +45,12 @@ def _storage_label(current: str | None) -> str:
     return mapping.get(current.lower(), current)
 
 
+
+
+def _build_callback(base: str, command_message_id: int | None) -> str:
+    if command_message_id is None:
+        return base
+    return f"{base}:{command_message_id}"
 def _backblaze_ready(config) -> bool:
     return bool(config.app_id and config.app_key and config.bucket_name)
 
@@ -61,7 +67,7 @@ def _md(line: str) -> str:
     return escape_markdown(line, version=2)
 
 
-async def bot_admin(page: int = 1) -> BotAdmin:
+async def bot_admin(page: int = 1, *, command_message_id: int | None = None) -> BotAdmin:
     allow_r18g = _is_truthy(await config_registry.get_config("allow_r18g"))
     enable_on_new_group = _is_truthy(await config_registry.get_config("enable_on_new_group"))
 
@@ -138,7 +144,10 @@ async def bot_admin(page: int = 1) -> BotAdmin:
                 callback_data="conf:bot:cache:menu",
             )
         ],
-        [InlineKeyboardButton("刷新", callback_data="conf:bot:panel:refresh")],
+        [
+            InlineKeyboardButton("刷新", callback_data=_build_callback("conf:bot:panel:refresh", command_message_id)),
+            InlineKeyboardButton("关闭", callback_data=_build_callback("conf:bot:panel:close", command_message_id)),
+        ],
     ]
 
     return BotAdmin(text=text, keyboard=keyboard)

--- a/messase_generator/config_user.py
+++ b/messase_generator/config_user.py
@@ -35,13 +35,19 @@ def _display_status(status: UserStatus | None) -> str:
     return _STATUS_LABELS.get(status, status.value)
 
 
+
+
+def _build_callback(base: str, command_message_id: int | None) -> str:
+    if command_message_id is None:
+        return base
+    return f"{base}:{command_message_id}"
 def _shorten(text: str, limit: int = 20) -> str:
     if len(text) <= limit:
         return text
     return f"{text[: limit - 1]}…"
 
 
-async def config_user(page: int = 1, user: User | None = None) -> ConfigUser:
+async def config_user(page: int = 1, user: User | None = None, *, command_message_id: int | None = None) -> ConfigUser:
     """Compose the inline configuration panel for the given user."""
 
     if user is None:
@@ -65,7 +71,10 @@ async def config_user(page: int = 1, user: User | None = None) -> ConfigUser:
     text = "\n".join(lines)
 
     keyboard: list[list[InlineKeyboardButton]] = [
-        [InlineKeyboardButton("刷新", callback_data="conf:user:panel:refresh")],
+        [
+            InlineKeyboardButton("刷新", callback_data=_build_callback("conf:user:panel:refresh", command_message_id)),
+            InlineKeyboardButton("关闭", callback_data=_build_callback("conf:user:panel:close", command_message_id)),
+        ],
         [InlineKeyboardButton(f"修改昵称 (当前: {display_nick})", callback_data="conf:user:nick:edit")],
         [
             InlineKeyboardButton(


### PR DESCRIPTION
- 新增 BOT_COMMAND_DEFINITIONS 常量定义支持的命令列表
- 在 bot.py 中实现 _register_commands 方法自动注册命令
- 添加 register_panel 和 close_panel 工具函数用于面板状态管理
- 更新 admin 和 option 命令处理器以支持面板消息跟踪
- 扩展回调处理程序以解析并响应包含 command_message_id 的操作- 修改多个配置面板生成器以支持关闭按钮和刷新时保留上下文
- 引入 panel_utils 模块统一管理面板交互逻辑