### PR TITLE
Add Pixiv illustration import command

### DIFF
--- a/handlers/command_handlers/add_pixiv_handler.py
+++ b/handlers/command_handlers/add_pixiv_handler.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from registries import config_registry
+from services import pixiv
+from services.command_history import command_logger
+from services.illustration_importer import import_illustration
+from handlers.registry import bot_handler
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_super_user_ids(value: str | bool | None) -> set[int]:
+    if value in (None, False):
+        return set()
+    if value is True:
+        return set()
+    text = str(value)
+    for ch in "\n\t\r":
+        text = text.replace(ch, " ")
+    tokens = [token.strip() for token in text.replace(",", " ").split(" ")]
+    ids: set[int] = set()
+    for token in tokens:
+        if not token:
+            continue
+        try:
+            ids.add(int(token))
+        except ValueError:
+            logger.debug("Skip invalid super user id token: %s", token)
+    return ids
+
+
+async def _require_super_user(user_id: int | None) -> bool:
+    config_value = await config_registry.get_config("super_user")
+    allowed = _parse_super_user_ids(config_value)
+    if not allowed:
+        return True
+    if user_id is None:
+        return False
+    return user_id in allowed
+
+
+def _build_chat_candidates(update: Update) -> list[int]:
+    candidates: list[int] = []
+    if update.effective_user is not None:
+        candidates.append(update.effective_user.id)
+    if update.effective_chat is not None and update.effective_chat.id not in candidates:
+        candidates.append(update.effective_chat.id)
+    return candidates
+
+
+def _format_page_summary(index: int, *, storage: bool, photo: bool, document: bool) -> str:
+    return (
+        f" - 第 {index + 1} 页："
+        f"存储{'成功' if storage else '失败'}，"
+        f"PhotoID{'已缓存' if photo else '缺失'}，"
+        f"DocumentID{'已缓存' if document else '缺失'}"
+    )
+
+
+@bot_handler(commands=["addpixiv"])
+@command_logger("addpixiv")
+async def add_pixiv_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not pixiv.enabled:
+        await update.effective_message.reply_text(
+            "Pixiv 功能未启用，请联系管理员配置令牌。"
+        )
+        return
+
+    args = context.args or []
+    if not args:
+        await update.effective_message.reply_text("请提供要导入的 Pixiv ID，例如 /addpixiv 12345678。")
+        return
+
+    pixiv_id_raw = args[0].strip()
+    try:
+        pixiv_id = int(pixiv_id_raw)
+    except ValueError:
+        await update.effective_message.reply_text("Pixiv ID 必须是数字。")
+        return
+
+    user_id = update.effective_user.id if update.effective_user else None
+    if not await _require_super_user(user_id):
+        await update.effective_message.reply_text("您没有权限使用此命令。")
+        return
+
+    status_message = await update.effective_message.reply_text("正在导入插画，请稍候……")
+    chat_candidates = _build_chat_candidates(update)
+
+    try:
+        result = await import_illustration(
+            pixiv_id,
+            bot=context.bot,
+            telegram_chat_ids=chat_candidates,
+        )
+    except Exception as exc:  # pragma: no cover - network interaction
+        logger.exception("Failed to import Pixiv illustration %s", pixiv_id)
+        await status_message.edit_text(f"导入失败：{exc}")
+        return
+
+    illustration = result.illustration
+    header = (
+        f"插画 {illustration.title or illustration.id} (Pixiv {illustration.id}) "
+        f"已{'新增' if result.created else '更新'}。"
+    )
+    summary_lines = [header, f"共处理 {len(result.pages)} 张图片。"]
+    for page in result.pages:
+        summary_lines.append(
+            _format_page_summary(
+                page.index,
+                storage=bool(page.storage_url),
+                photo=bool(page.compressed_file_id),
+                document=bool(page.original_file_id),
+            )
+        )
+
+    await status_message.edit_text("\n".join(summary_lines))

--- a/handlers/command_handlers/all_command_handlers.py
+++ b/handlers/command_handlers/all_command_handlers.py
@@ -3,7 +3,7 @@
 from handlers.registry import iter_bot_handlers
 
 # Import modules for side effects so their handlers register before aggregation.
-from . import admin_handler, option_handler, p_info_handler, setu_handler
+from . import add_pixiv_handler, admin_handler, option_handler, p_info_handler, setu_handler
 
 
 all_command_handlers = iter_bot_handlers()

--- a/registries/illust_registry.py
+++ b/registries/illust_registry.py
@@ -40,3 +40,12 @@ async def random_illust(sanity_limit: int = 5, r18g: bool = False):
 
         result = await session.execute(stmt)
         return result.scalars().first()
+
+
+async def save_illustration(illust: Illustration) -> Illustration:
+    async with engine.new_session() as session:
+        session: AsyncSession = session
+        merged = await session.merge(illust)
+        await session.commit()
+        await session.refresh(merged)
+        return merged

--- a/services/file_service/download_file.py
+++ b/services/file_service/download_file.py
@@ -32,11 +32,8 @@ async def download_file(filename: str, url: str, replace: bool = False):
                                     await f.write(await response.content.read())
                                 return
                             else:
-                                raise aiohttp.HttpProcessingError(
-                                    message=f"Error {response.status} while downloading file.",
-                                    code=response.status,
-                                )
-                except (aiohttp.ClientError, aiohttp.HttpProcessingError) as e:
+                                response.raise_for_status()
+                except aiohttp.ClientError as e:
                     print(f"Attempt {attempt} failed: {e}")
                     attempt += 1
                     if attempt >= retries:

--- a/services/file_service/download_file.py
+++ b/services/file_service/download_file.py
@@ -25,7 +25,9 @@ async def download_file(filename: str, url: str, replace: bool = False):
                     # 创建一个 ClientTimeout 对象
                     timeout_settings = aiohttp.ClientTimeout(total=10)
                     async with aiohttp.ClientSession(timeout=timeout_settings) as session:
-                        async with session.get(url) as response:
+                        # Pixiv 的资源接口需要带 Referer 头，否则会返回 403。
+                        headers = {"Referer": "https://app-api.pixiv.net/"}
+                        async with session.get(url, headers=headers) as response:
                             if response.status == 200:
                                 # 打开文件准备写入
                                 async with aiofiles.open(file_url, 'wb') as f:

--- a/services/file_service/file_lock.py
+++ b/services/file_service/file_lock.py
@@ -10,12 +10,14 @@ def get_dick_lock() -> aiorwlock.RWLock:
 
 
 def get_lock(lock_name: str) -> tuple[aiorwlock.RWLock, asyncio.Lock]:
-    if lock_name in file_locks:
-        return file_locks[lock_name]
-    else:
+    """Return a tuple containing the global dict lock and a per-file lock."""
+
+    lock = file_locks.get(lock_name)
+    if lock is None:
         lock = asyncio.Lock()
         file_locks[lock_name] = lock
-        return dict_lock, lock
+
+    return dict_lock, lock
 
 
 def del_lock(lock_name: str) -> None:

--- a/services/illustration_importer.py
+++ b/services/illustration_importer.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from io import BytesIO
+from typing import Sequence
+
+from telegram import Bot
+from telegram.error import TelegramError
+
+from models import Illustration
+from registries import illust_registry
+from services.file_service import get_file
+from services.pixiv_service import pixiv
+from services.storage_service import use as use_storage
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ImportedPage:
+    index: int
+    storage_url: str
+    compressed_file_id: str | None
+    original_file_id: str | None
+
+
+@dataclass(slots=True)
+class IllustrationImportResult:
+    illustration: Illustration
+    created: bool
+    pages: list[ImportedPage] = field(default_factory=list)
+
+
+def _unique_chat_ids(chat_ids: Sequence[int] | None) -> list[int]:
+    if not chat_ids:
+        return []
+    seen: set[int] = set()
+    ordered: list[int] = []
+    for chat_id in chat_ids:
+        if chat_id in seen:
+            continue
+        seen.add(chat_id)
+        ordered.append(chat_id)
+    return ordered
+
+
+async def _cache_photo_file_id(
+    bot: Bot,
+    chat_ids: list[int],
+    data: bytes,
+    filename: str,
+    *,
+    cleanup: bool,
+) -> tuple[str | None, int | None]:
+    last_error: Exception | None = None
+    for chat_id in chat_ids:
+        try:
+            stream = BytesIO(data)
+            stream.name = filename
+            message = await bot.send_photo(
+                chat_id=chat_id,
+                photo=stream,
+                disable_notification=True,
+            )
+        except TelegramError as exc:  # pragma: no cover - network interaction
+            last_error = exc
+            logger.debug("Failed to cache photo file id in chat %s: %s", chat_id, exc)
+            continue
+        compressed_id = message.photo[-1].file_id if message.photo else None
+        if cleanup:
+            try:
+                await bot.delete_message(chat_id=chat_id, message_id=message.message_id)
+            except TelegramError as exc:  # pragma: no cover - best effort cleanup
+                logger.debug("Failed to delete temporary photo message: %s", exc)
+        return compressed_id, chat_id
+    if last_error is not None:
+        logger.warning("无法缓存压缩文件 ID: %s", last_error)
+    return None, None
+
+
+async def _cache_document_file_id(
+    bot: Bot,
+    chat_ids: list[int],
+    data: bytes,
+    filename: str,
+    *,
+    cleanup: bool,
+) -> str | None:
+    last_error: Exception | None = None
+    for chat_id in chat_ids:
+        try:
+            stream = BytesIO(data)
+            stream.name = filename
+            message = await bot.send_document(
+                chat_id=chat_id,
+                document=stream,
+                disable_notification=True,
+            )
+        except TelegramError as exc:  # pragma: no cover - network interaction
+            last_error = exc
+            logger.debug("Failed to cache document file id in chat %s: %s", chat_id, exc)
+            continue
+        file_id = message.document.file_id if message.document else None
+        if cleanup:
+            try:
+                await bot.delete_message(chat_id=chat_id, message_id=message.message_id)
+            except TelegramError as exc:  # pragma: no cover - best effort cleanup
+                logger.debug("Failed to delete temporary document message: %s", exc)
+        return file_id
+    if last_error is not None:
+        logger.warning("无法缓存原图文件 ID: %s", last_error)
+    return None
+
+
+def _ensure_list(container: object, length: int) -> list:
+    if isinstance(container, list):
+        if len(container) < length:
+            container.extend([None] * (length - len(container)))
+        return container
+    return [None] * length
+
+
+async def import_illustration(
+    pixiv_id: int,
+    *,
+    bot: Bot | None = None,
+    telegram_chat_ids: Sequence[int] | None = None,
+    cleanup_messages: bool = True,
+) -> IllustrationImportResult:
+    if not pixiv.enabled:
+        raise RuntimeError("Pixiv 功能未启用")
+
+    illust = await pixiv.get_illust_info_by_pixiv_id(pixiv_id)
+    storage = await use_storage()
+    if storage is None:
+        raise RuntimeError("未配置存储服务，请先在后台完成配置。")
+
+    storage_folder = storage.join_path("pixiv", str(illust.id))
+    existing = await illust_registry.get_illust_info(str(illust.id))
+    created = existing is None
+
+    chat_candidates = _unique_chat_ids(telegram_chat_ids)
+
+    illust.file_urls = _ensure_list(getattr(illust, "file_urls", None), illust.page_count)
+    illust.compressed_file_ids = _ensure_list(getattr(illust, "compressed_file_ids", None), illust.page_count)
+    illust.original_file_ids = _ensure_list(getattr(illust, "original_file_ids", None), illust.page_count)
+
+    pages: list[ImportedPage] = []
+    for page_index in range(illust.page_count):
+        origin_url: str | None = None
+        if isinstance(illust.origin_urls, list):
+            if page_index < len(illust.origin_urls):
+                origin_url = illust.origin_urls[page_index]
+        elif isinstance(illust.origin_urls, str):
+            origin_url = illust.origin_urls
+        if not origin_url:
+            raise RuntimeError(f"缺少第 {page_index + 1} 页的原图链接")
+
+        ext: str | None = None
+        if isinstance(illust.file_ext, list):
+            if page_index < len(illust.file_ext):
+                ext = illust.file_ext[page_index]
+        elif isinstance(illust.file_ext, str):
+            ext = illust.file_ext
+        if not ext:
+            ext = ".jpg"
+        if not ext.startswith("."):
+            ext = f".{ext}"
+
+        filename = f"{illust.id}_{page_index:02d}{ext}"
+        file_bytes = await get_file(filename=filename, url=origin_url)
+        if file_bytes is None:
+            raise RuntimeError(f"无法下载第 {page_index + 1} 页的图片")
+
+        storage_url = await storage.upload(
+            file_bytes,
+            filename,
+            sub_folder=storage_folder,
+        )
+
+        compressed_id: str | None = None
+        original_id: str | None = None
+        if bot is not None and chat_candidates:
+            compressed_id, used_chat = await _cache_photo_file_id(
+                bot,
+                chat_candidates,
+                file_bytes,
+                filename,
+                cleanup=cleanup_messages,
+            )
+            doc_chat_order = chat_candidates
+            if used_chat is not None:
+                doc_chat_order = [used_chat] + [cid for cid in chat_candidates if cid != used_chat]
+            original_id = await _cache_document_file_id(
+                bot,
+                doc_chat_order,
+                file_bytes,
+                filename,
+                cleanup=cleanup_messages,
+            )
+
+        illust.file_urls[page_index] = storage_url
+        illust.compressed_file_ids[page_index] = compressed_id
+        illust.original_file_ids[page_index] = original_id
+
+        pages.append(
+            ImportedPage(
+                index=page_index,
+                storage_url=storage_url,
+                compressed_file_id=compressed_id,
+                original_file_id=original_id,
+            )
+        )
+
+    saved = await illust_registry.save_illustration(illust)
+    saved.file_urls = illust.file_urls
+    saved.compressed_file_ids = illust.compressed_file_ids
+    saved.original_file_ids = illust.original_file_ids
+
+    return IllustrationImportResult(
+        illustration=saved,
+        created=created,
+        pages=pages,
+    )


### PR DESCRIPTION
## Summary
- add an /addpixiv admin command that validates permissions and imports Pixiv illustrations on demand
- implement an illustration importer that saves metadata, uploads files to the configured storage, and caches Telegram file IDs
- enhance illustration metadata handling and file caching to work with storage-backed files

## Testing
- pytest
- python -m compileall handlers/command_handlers/add_pixiv_handler.py services/illustration_importer.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd84d92c4832faa57b168651b263f