### PR TITLE
Add group configuration panel for /option command

### DIFF
--- a/handlers/callback_handlers/conf_handlers/conf_handler.py
+++ b/handlers/callback_handlers/conf_handlers/conf_handler.py
@@ -2,11 +2,17 @@ from telegram import Update
 from telegram.ext import ContextTypes
 
 from handlers.callback_handlers.conf_handlers.bot.bot_conf_handler import bot_conf_handler_func
-from handlers.callback_handlers.conf_handlers.user_conf_handlers import user_conf_handler_func
+from handlers.callback_handlers.conf_handlers.group_conf_handlers import (
+    group_conf_handler_func,
+)
+from handlers.callback_handlers.conf_handlers.user_conf_handlers import (
+    user_conf_handler_func,
+)
 
 handler_map = {
     "user": user_conf_handler_func,
     "bot": bot_conf_handler_func,
+    "group": group_conf_handler_func,
 }
 
 

--- a/handlers/callback_handlers/conf_handlers/group_conf_handlers/__init__.py
+++ b/handlers/callback_handlers/conf_handlers/group_conf_handlers/__init__.py
@@ -1,0 +1,5 @@
+"""Callback handlers for group configuration panels."""
+
+from .group_conf_handler import group_conf_handler_func
+
+__all__ = ["group_conf_handler_func"]

--- a/handlers/callback_handlers/conf_handlers/group_conf_handlers/chat_placeholder.py
+++ b/handlers/callback_handlers/conf_handlers/group_conf_handlers/chat_placeholder.py
@@ -1,0 +1,23 @@
+"""Placeholder handler for the unimplemented AI chat toggle."""
+
+from __future__ import annotations
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+
+async def handle_chat_placeholder(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    group_id: int,
+    args: list[str],
+    command_message_id: int | None,
+) -> None:
+    del context, group_id, args, command_message_id
+
+    query = update.callback_query
+    if query is None:
+        return
+
+    await query.answer("AI 聊天功能暂未实现", show_alert=True)

--- a/handlers/callback_handlers/conf_handlers/group_conf_handlers/enable.py
+++ b/handlers/callback_handlers/conf_handlers/group_conf_handlers/enable.py
@@ -1,0 +1,42 @@
+"""Callback helpers for toggling group enablement."""
+
+from __future__ import annotations
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from registries import group_registry
+
+from .panel import refresh_group_config_panel
+
+
+async def handle_enable_toggle(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    group_id: int,
+    args: list[str],
+    command_message_id: int | None,
+) -> None:
+    query = update.callback_query
+    if query is None or not args:
+        return
+
+    action = args[0]
+    if action not in {"on", "off"}:
+        await query.answer()
+        return
+
+    enable = action == "on"
+
+    await group_registry.set_group_enable(group_id, enable)
+
+    await query.answer("机器人已启用" if enable else "机器人已禁用")
+
+    await refresh_group_config_panel(
+        context,
+        chat_id=update.effective_chat.id,
+        message_id=update.effective_message.message_id,
+        group_id=group_id,
+        command_message_id=command_message_id,
+    )

--- a/handlers/callback_handlers/conf_handlers/group_conf_handlers/group_conf_handler.py
+++ b/handlers/callback_handlers/conf_handlers/group_conf_handlers/group_conf_handler.py
@@ -1,0 +1,114 @@
+"""Entry point for group configuration callback handling."""
+
+from __future__ import annotations
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from handlers.callback_handlers.panel_utils import close_panel
+from registries import group_registry
+
+from .chat_placeholder import handle_chat_placeholder
+from .enable import handle_enable_toggle
+from .panel import refresh_group_config_panel
+from .r18 import handle_r18_toggle
+
+
+def _parse_command_message_id(cmd_parts: list[str]) -> int | None:
+    if not cmd_parts:
+        return None
+    candidate = cmd_parts[-1]
+    try:
+        return int(candidate)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_args(cmd_parts: list[str]) -> tuple[int | None, list[str]]:
+    if len(cmd_parts) <= 2:
+        return None, []
+    candidate = cmd_parts[-1]
+    try:
+        command_message_id = int(candidate)
+    except (TypeError, ValueError):
+        return None, cmd_parts[2:]
+    return command_message_id, cmd_parts[2:-1]
+
+
+_HANDLER_MAP = {
+    "enable": handle_enable_toggle,
+    "r18": handle_r18_toggle,
+    "chat": handle_chat_placeholder,
+}
+
+
+async def group_conf_handler_func(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, cmd: list[str]
+):
+    query = update.callback_query
+    if query is None or not cmd:
+        return
+
+    chat = update.effective_chat
+    if chat is None:
+        await query.answer()
+        return
+
+    try:
+        group_id = int(cmd[0])
+    except (TypeError, ValueError):
+        await query.answer("无法识别的群组", show_alert=True)
+        return
+
+    if chat.id != group_id:
+        await query.answer("无效的群组操作", show_alert=True)
+        return
+
+    group = await group_registry.get_group_by_id(group_id)
+    admin_ids = set(group.admin_ids or [])
+    user_id = update.effective_user.id
+    if admin_ids and user_id not in admin_ids:
+        await query.answer("只有群组管理员可以执行此操作", show_alert=True)
+        return
+
+    if len(cmd) == 1:
+        await query.answer()
+        return
+
+    section = cmd[1]
+
+    if section == "panel" and len(cmd) > 2:
+        action = cmd[2]
+        command_message_id = _parse_command_message_id(cmd)
+        if action == "refresh":
+            await refresh_group_config_panel(
+                context,
+                chat_id=chat.id,
+                message_id=update.effective_message.message_id,
+                group_id=group_id,
+                command_message_id=command_message_id,
+            )
+            await query.answer("已刷新")
+            return
+        if action == "close":
+            await close_panel(
+                update,
+                context,
+                command_message_id=command_message_id,
+            )
+            return
+
+    handler = _HANDLER_MAP.get(section)
+    if handler is None:
+        await query.answer()
+        return
+
+    command_message_id, args = _extract_args(cmd)
+
+    await handler(
+        update,
+        context,
+        group_id=group_id,
+        args=args,
+        command_message_id=command_message_id,
+    )

--- a/handlers/callback_handlers/conf_handlers/group_conf_handlers/panel.py
+++ b/handlers/callback_handlers/conf_handlers/group_conf_handlers/panel.py
@@ -1,0 +1,57 @@
+"""Utilities for refreshing the Telegram group configuration panel."""
+
+from __future__ import annotations
+
+import logging
+
+from telegram import InlineKeyboardMarkup
+from telegram.error import TelegramError
+from telegram.ext import ContextTypes
+
+import messase_generator
+from handlers.callback_handlers.panel_utils import (
+    get_panel_command_message_id,
+    register_panel,
+)
+from registries import group_registry
+
+logger = logging.getLogger(__name__)
+
+
+async def refresh_group_config_panel(
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    chat_id: int,
+    message_id: int,
+    group_id: int,
+    command_message_id: int | None = None,
+) -> None:
+    """Re-render the group configuration panel in place."""
+
+    group = await group_registry.get_group_by_id(group_id)
+    if command_message_id is None:
+        command_message_id = get_panel_command_message_id(context, message_id)
+
+    panel = await messase_generator.config_group(
+        group=group, command_message_id=command_message_id
+    )
+
+    try:
+        await context.bot.edit_message_text(
+            chat_id=chat_id,
+            message_id=message_id,
+            text=panel.text,
+        )
+        await context.bot.edit_message_reply_markup(
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup=InlineKeyboardMarkup(panel.keyboard),
+        )
+        register_panel(context, message_id, command_message_id)
+    except TelegramError as exc:
+        logger.warning(
+            "Failed to refresh group config panel for chat %s message %s: %s",
+            chat_id,
+            message_id,
+            exc,
+        )

--- a/handlers/callback_handlers/conf_handlers/group_conf_handlers/r18.py
+++ b/handlers/callback_handlers/conf_handlers/group_conf_handlers/r18.py
@@ -1,0 +1,46 @@
+"""Callback helpers for toggling group R18 allowances."""
+
+from __future__ import annotations
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from registries import group_registry
+
+from .panel import refresh_group_config_panel
+
+_R18_SANITY_LIMIT = 7
+_DEFAULT_SANITY_LIMIT = 5
+
+
+async def handle_r18_toggle(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    group_id: int,
+    args: list[str],
+    command_message_id: int | None,
+) -> None:
+    query = update.callback_query
+    if query is None or not args:
+        return
+
+    action = args[0]
+    if action not in {"on", "off"}:
+        await query.answer()
+        return
+
+    allow_r18 = action == "on"
+    sanity_limit = _R18_SANITY_LIMIT if allow_r18 else _DEFAULT_SANITY_LIMIT
+
+    await group_registry.set_group_sanity_limit(group_id, sanity_limit)
+
+    await query.answer("已允许 R18" if allow_r18 else "已禁止 R18")
+
+    await refresh_group_config_panel(
+        context,
+        chat_id=update.effective_chat.id,
+        message_id=update.effective_message.message_id,
+        group_id=group_id,
+        command_message_id=command_message_id,
+    )

--- a/messase_generator/__init__.py
+++ b/messase_generator/__init__.py
@@ -1,2 +1,3 @@
 from .config_user import config_user
+from .config_group import config_group
 from .bot_admin import bot_admin

--- a/messase_generator/config_group.py
+++ b/messase_generator/config_group.py
@@ -1,0 +1,90 @@
+"""Generation helpers for the Telegram group configuration panel."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from telegram import InlineKeyboardButton
+
+from models import Group
+
+
+@dataclass(slots=True)
+class ConfigGroup:
+    """Container for the rendered group configuration panel."""
+
+    text: str
+    keyboard: list[list[InlineKeyboardButton]]
+
+
+def _bool_icon(value: bool) -> str:
+    return "✅" if value else "❌"
+
+
+def _build_callback(group_id: int, suffix: str, command_message_id: int | None) -> str:
+    base = f"conf:group:{group_id}:{suffix}"
+    if command_message_id is None:
+        return base
+    return f"{base}:{command_message_id}"
+
+
+async def config_group(*, group: Group | None = None, command_message_id: int | None = None) -> ConfigGroup:
+    """Compose the inline configuration panel for the given group."""
+
+    if group is None:
+        raise ValueError("group 不能为空")
+
+    allow_r18 = group.sanity_limit >= 7
+
+    lines = [
+        "群组配置面板",
+        "",
+        f"群组 ID: {group.id}",
+        f"名称: {group.name or '未设置'}",
+        f"机器人启用: {_bool_icon(group.enable)}",
+        f"允许 R18: {_bool_icon(allow_r18)}",
+        "AI 聊天: 🚧 暂未实现",
+    ]
+
+    text = "\n".join(lines)
+
+    keyboard: list[list[InlineKeyboardButton]] = [
+        [
+            InlineKeyboardButton(
+                "刷新",
+                callback_data=_build_callback(group.id, "panel:refresh", command_message_id),
+            ),
+            InlineKeyboardButton(
+                "关闭",
+                callback_data=_build_callback(group.id, "panel:close", command_message_id),
+            ),
+        ],
+        [
+            InlineKeyboardButton(
+                "禁用机器人" if group.enable else "启用机器人",
+                callback_data=_build_callback(
+                    group.id,
+                    "enable:off" if group.enable else "enable:on",
+                    command_message_id,
+                ),
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "禁止 R18" if allow_r18 else "允许 R18",
+                callback_data=_build_callback(
+                    group.id,
+                    "r18:off" if allow_r18 else "r18:on",
+                    command_message_id,
+                ),
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "AI 聊天 (暂未实现)",
+                callback_data=_build_callback(group.id, "chat:todo", command_message_id),
+            )
+        ],
+    ]
+
+    return ConfigGroup(text=text, keyboard=keyboard)

--- a/registries/group_registry.py
+++ b/registries/group_registry.py
@@ -1,4 +1,4 @@
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models import Group
@@ -23,3 +23,21 @@ async def get_group_by_id(group_id: int) -> Group:
             await add_group(new_group)
             return await get_group_by_id(group_id)
         return group
+
+
+async def set_group_enable(group_id: int, enable: bool) -> None:
+    async with engine.new_session() as session:
+        session: AsyncSession = session
+        await session.execute(
+            update(Group).where(Group.id == group_id).values(enable=enable)
+        )
+        await session.commit()
+
+
+async def set_group_sanity_limit(group_id: int, sanity_limit: int) -> None:
+    async with engine.new_session() as session:
+        session: AsyncSession = session
+        await session.execute(
+            update(Group).where(Group.id == group_id).values(sanity_limit=sanity_limit)
+        )
+        await session.commit()


### PR DESCRIPTION
## Summary
- add a group configuration panel to /option that is available to group administrators
- implement callback handlers to toggle group enablement and R18 allowance while marking AI chat as not yet implemented
- extend registries and message generators to render and update the new group management panel

## Testing
- python -m compileall handlers messase_generator registries

------
https://chatgpt.com/codex/tasks/task_e_68dff6ee5e60832fbb36bef8d80cf6de