### PR TITLE
Fix SSRF in Pixiv image proxy

### DIFF
--- a/routers/illustrations.py
+++ b/routers/illustrations.py
@@ -7,7 +7,7 @@ user review/adjust fields, then confirm to download + store + persist.
 from __future__ import annotations
 
 import os
-from urllib.parse import urlparse
+from urllib.parse import urlsplit, urlunsplit
 
 import aiohttp
 from fastapi import APIRouter, HTTPException, Response
@@ -28,13 +28,20 @@ from services.illustration_import_runner import (
 router = APIRouter(prefix="/api/illustrations", tags=["illustrations"])
 
 _PIXIV_CDN_HOST = "i.pximg.net"
+_PIXIV_CDN_ORIGIN = f"https://{_PIXIV_CDN_HOST}"
 
 
-async def _fetch_pixiv_bytes(url: str) -> bytes:
+async def _fetch_pixiv_bytes(relative_url: str) -> bytes:
     timeout = aiohttp.ClientTimeout(total=15)
     headers = {"Referer": "https://app-api.pixiv.net/"}
-    async with aiohttp.ClientSession(timeout=timeout) as session:
-        async with session.get(url, headers=headers) as response:
+    # Keep the network destination independent from request data.  Using a fixed
+    # base URL also makes the SSRF boundary explicit for static analysis.
+    async with aiohttp.ClientSession(
+        base_url=_PIXIV_CDN_ORIGIN, timeout=timeout
+    ) as session:
+        async with session.get(
+            relative_url, headers=headers, allow_redirects=False
+        ) as response:
             if response.status != 200:
                 raise HTTPException(
                     status_code=502, detail=f"获取图片失败：HTTP {response.status}"
@@ -228,17 +235,33 @@ async def preview_illustration(payload: PixivIdPayload) -> IllustrationPreviewRe
 @router.get("/image")
 async def proxy_image(url: str) -> Response:
     """Proxy a Pixiv CDN image (requires a referer header) for inline preview."""
-    parsed = urlparse(url)
-    if parsed.scheme not in {"http", "https"} or parsed.netloc.lower() != _PIXIV_CDN_HOST:
+    try:
+        parsed = urlsplit(url)
+        port = parsed.port
+    except ValueError:
         raise HTTPException(status_code=400, detail="仅允许代理 Pixiv CDN 图片")
 
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname is None
+        or parsed.hostname.lower() != _PIXIV_CDN_HOST
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or not parsed.path.startswith("/")
+        or parsed.path.startswith("//")
+    ):
+        raise HTTPException(status_code=400, detail="仅允许代理 Pixiv CDN 图片")
+
+    # Pass only the path and query to the HTTP client.  The scheme and authority
+    # are supplied by the trusted constant in _fetch_pixiv_bytes.
+    relative_url = urlunsplit(("", "", parsed.path, parsed.query, ""))
+
     try:
-        content = await _fetch_pixiv_bytes(url)
+        content = await _fetch_pixiv_bytes(relative_url)
     except HTTPException:
         raise
     except Exception as exc:
         raise HTTPException(status_code=502, detail=f"获取图片失败：{exc}")
 
     return Response(content=content, media_type=_guess_media_type(parsed.path))
-
-

--- a/tests/system/test_api_illustrations.py
+++ b/tests/system/test_api_illustrations.py
@@ -130,15 +130,35 @@ def test_proxy_rejects_non_pixiv_domain(client):
     assert response.status_code == 400
 
 
+def test_proxy_rejects_untrusted_url_components(client):
+    urls = [
+        "http://i.pximg.net/x.jpg",
+        "https://user@i.pximg.net/x.jpg",
+        "https://i.pximg.net:443/x.jpg",
+        "https://i.pximg.net:invalid/x.jpg",
+        "https://i.pximg.net//evil.example/x.jpg",
+    ]
+
+    for url in urls:
+        response = client.get("/api/illustrations/image", params={"url": url})
+        assert response.status_code == 400, url
+
+
 def test_proxy_returns_image(client, monkeypatch):
+    fetched_urls = []
+
     async def fake_fetch(url: str) -> bytes:
+        fetched_urls.append(url)
         return b"\xff\xd8fakejpeg"
 
     monkeypatch.setattr("routers.illustrations._fetch_pixiv_bytes", fake_fetch)
     response = client.get(
         "/api/illustrations/image",
-        params={"url": "https://i.pximg.net/img-master/200_p0_master1200.jpg"},
+        params={
+            "url": "https://i.pximg.net/img-master/200_p0_master1200.jpg?token=test#ignored"
+        },
     )
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/jpeg"
     assert response.content == b"\xff\xd8fakejpeg"
+    assert fetched_urls == ["/img-master/200_p0_master1200.jpg?token=test"]


### PR DESCRIPTION
### Motivation

- The image proxy accepted user-supplied full URLs and forwarded them to the HTTP client, allowing server-side request forgery (SSRF) to arbitrary hosts. 

### Description

- Restrict proxy input and parse URLs with `urlsplit`/`urlunsplit`, validating scheme, hostname, absence of credentials, absence of explicit port, and disallowing authority-like `//` paths. 
- Build a sanitized relative path/query and pass only that to the downloader, changing `_fetch_pixiv_bytes` to accept a `relative_url` and to use a fixed `_PIXIV_CDN_ORIGIN` via `aiohttp.ClientSession(base_url=...)` with `allow_redirects=False`. 
- Add checks that only `https://i.pximg.net` requests are allowed and reject malformed ports and other untrusted URL components. 
- Add system tests in `tests/system/test_api_illustrations.py` to cover rejected URL components and to assert that the actual fetch receives the sanitized relative URL. 

### Testing

- Ran `pytest tests/system/test_api_illustrations.py -q` and the test suite for the illustrations endpoints passed. 
- Ran the full test suite with `pytest -q` and all tests passed. 
- Added tests exercised the proxy behavior and verified the downloader was invoked with the expected sanitized relative URL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a742ee514f0832fa7953e529109182a)