### PR TITLE
Redirect `/` to `/admin/` when built admin WebUI is served

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ from registries.config_registry import init_database_config
 from services import pixiv, storage_service, schema_migrator
 from utils.logging_config import setup_logging
 from utils import frontend_launcher
-from utils.admin_static import AdminStaticFiles
+from utils.admin_static import AdminStaticFiles, redirect_to_admin
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -103,11 +103,11 @@ dist_dir = webui_dir / "dist"
 # （http://localhost:5173/admin/）提供服务。
 if dist_dir.exists():
     app.mount("/admin", AdminStaticFiles(directory=dist_dir, html=True), name="admin")
-
-
-@app.get("/")
-async def root():
-    return {"message": "Hello World"}
+    app.add_api_route("/", redirect_to_admin, include_in_schema=False)
+else:
+    @app.get("/")
+    async def root():
+        return {"message": "Hello World"}
 
 
 @app.get("/hello/{name}")

--- a/tests/unit/test_admin_static.py
+++ b/tests/unit/test_admin_static.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from utils.admin_static import AdminStaticFiles
+from utils.admin_static import AdminStaticFiles, redirect_to_admin
 
 
 def test_admin_static_files_support_spa_history_routes(tmp_path: Path):
@@ -23,3 +23,16 @@ def test_admin_static_files_support_spa_history_routes(tmp_path: Path):
     assert route_response.text == index_response.text
     assert asset_response.status_code == 200
     assert asset_response.text == "console.log('admin')"
+
+
+def test_root_redirects_to_built_in_admin_webui(tmp_path: Path):
+    (tmp_path / "index.html").write_text("<h1>Admin console</h1>", encoding="utf-8")
+    app = FastAPI()
+    app.mount("/admin", AdminStaticFiles(directory=tmp_path, html=True))
+    app.add_api_route("/", redirect_to_admin)
+
+    with TestClient(app, follow_redirects=False) as client:
+        response = client.get("/")
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/admin/"

--- a/utils/admin_static.py
+++ b/utils/admin_static.py
@@ -1,7 +1,7 @@
 """Static file server for the built admin single-page application."""
 
 from starlette.exceptions import HTTPException
-from starlette.responses import Response
+from starlette.responses import RedirectResponse, Response
 from starlette.staticfiles import StaticFiles
 
 
@@ -15,3 +15,9 @@ class AdminStaticFiles(StaticFiles):
             if exc.status_code != 404:
                 raise
             return await super().get_response("index.html", scope)
+
+
+async def redirect_to_admin() -> RedirectResponse:
+    """Redirect the application root to the built-in admin web UI."""
+
+    return RedirectResponse(url="/admin/")


### PR DESCRIPTION
### Motivation

- When the admin WebUI is provided by FastAPI's static server (production build in `webui/dist`), visiting the application root `/` should route users to the admin UI instead of returning the default JSON payload.

### Description

- Add `redirect_to_admin` in `utils/admin_static.py` which returns a `RedirectResponse` to `"/admin/"`.
- When `webui/dist` exists, mount the SPA with `AdminStaticFiles` and register the root route to call `redirect_to_admin` using `app.add_api_route("/", redirect_to_admin, include_in_schema=False)` in `main.py`.
- Preserve the existing JSON root endpoint when the built WebUI is not present (development mode remains unchanged).
- Add `tests/unit/test_admin_static.py::test_root_redirects_to_built_in_admin_webui` to verify the root returns a 307 redirect with `Location: /admin/`.

### Testing

- Ran `pytest tests/unit/test_admin_static.py` which passed (`2 passed`).
- Ran `python -m compileall -q main.py utils/admin_static.py tests/unit/test_admin_static.py` which completed successfully.
- Ran `git diff --check` to ensure no whitespace/patch issues (no problems found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74528d7aa0832fbd2cfe1209793059)