### PR TITLE
在 PR 中报告单元测试覆盖率

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -120,17 +120,9 @@ jobs:
               `[🔍 View workflow run](${run.html_url})`,
             ].join('\n');
 
-            const comments = await github.paginate(github.rest.issues.listComments, {
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: number,
+              body,
             });
-            const previous = comments.find(comment =>
-              comment.user.type === 'Bot' && comment.body.includes(marker)
-            );
-            const common = {owner: context.repo.owner, repo: context.repo.repo, body};
-            if (previous) {
-              await github.rest.issues.updateComment({...common, comment_id: previous.id});
-            } else {
-              await github.rest.issues.createComment({...common, issue_number: number});
-            }

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -1,0 +1,136 @@
+name: Coverage report
+
+on:
+  workflow_run:
+    workflows: [Tests]
+    types: [completed]
+
+# workflow_run executes from the trusted default branch, so it can comment on
+# fork PRs without exposing a write token to their code.
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  report:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.pull_requests[0] != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download coverage report
+        uses: actions/download-artifact@v7
+        with:
+          name: coverage-report
+          path: coverage-artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Never execute or interpolate artifact contents: a fork controls this JSON.
+      - name: Comment on pull request
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const coverage = JSON.parse(fs.readFileSync('coverage-artifact/coverage.json', 'utf8'));
+            const totals = coverage.totals;
+            const pr = context.payload.workflow_run.pull_requests[0];
+            const number = pr.number;
+
+            // Ignore stale runs after the pull request has received another push.
+            const {data: currentPr} = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: number,
+            });
+            if (currentPr.head.sha !== context.payload.workflow_run.head_sha) {
+              core.notice('Skipping stale coverage report');
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: number,
+              per_page: 100,
+            });
+            const addedLines = new Map();
+            for (const file of files) {
+              if (!file.patch) continue;
+              const lines = new Set();
+              let newLine = 0;
+              for (const line of file.patch.split('\n')) {
+                if (line.startsWith('@@')) {
+                  const match = line.match(/\+(\d+)(?:,(\d+))?/);
+                  if (match) newLine = Number(match[1]);
+                } else if (line.startsWith('+')) {
+                  lines.add(newLine++);
+                } else if (!line.startsWith('-') && !line.startsWith('\\')) {
+                  newLine++;
+                }
+              }
+              addedLines.set(file.filename, lines);
+            }
+
+            let addedStatements = 0;
+            let coveredAddedStatements = 0;
+            for (const [file, lines] of addedLines) {
+              const fileCoverage = coverage.files[file];
+              if (!fileCoverage) continue;
+              const executed = new Set(fileCoverage.executed_lines);
+              const missing = new Set(fileCoverage.missing_lines);
+              for (const line of lines) {
+                if (executed.has(line) || missing.has(line)) addedStatements++;
+                if (executed.has(line)) coveredAddedStatements++;
+              }
+            }
+
+            const integer = value => Number.isSafeInteger(value) && value >= 0 ? value : 0;
+            const coveredLines = integer(totals.covered_lines);
+            const statements = integer(totals.num_statements);
+            const missingLines = integer(totals.missing_lines);
+            const coveredBranches = integer(totals.covered_branches);
+            const branches = integer(totals.num_branches);
+            const percentage = (covered, total) => total
+              ? `${(covered / total * 100).toFixed(2)}%`
+              : 'N/A';
+            const addedCoverage = addedStatements
+              ? `${coveredAddedStatements} / ${addedStatements} (${percentage(coveredAddedStatements, addedStatements)})`
+              : 'N/A (no executable lines added)';
+            const branchCoverage = branches
+              ? `${coveredBranches} / ${branches} (${percentage(coveredBranches, branches)})`
+              : 'N/A';
+            const marker = '<!-- pytest-coverage-report -->';
+            const run = context.payload.workflow_run;
+            const body = [
+              marker,
+              '## 🧪 Unit test coverage',
+              '',
+              '| Metric | Result |',
+              '| --- | ---: |',
+              `| **New code lines** | **${addedCoverage}** |`,
+              `| All code lines | ${coveredLines} / ${statements} (${percentage(coveredLines, statements)}) |`,
+              `| All code missing lines | ${missingLines} |`,
+              `| All code branches | ${branchCoverage} |`,
+              '',
+              '> Coverage is currently informational only; no minimum threshold is enforced.',
+              '',
+              `[🔍 View workflow run](${run.html_url})`,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+            });
+            const previous = comments.find(comment =>
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            );
+            const common = {owner: context.repo.owner, repo: context.repo.repo, body};
+            if (previous) {
+              await github.rest.issues.updateComment({...common, comment_id: previous.id});
+            } else {
+              await github.rest.issues.createComment({...common, issue_number: number});
+            }

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -57,8 +57,15 @@ jobs:
               per_page: 100,
             });
             const addedLines = new Map();
+            let missingSourcePatches = 0;
             for (const file of files) {
-              if (!file.patch) continue;
+              if (!file.patch) {
+                // The files API can omit patches for large diffs. Do not present
+                // partial new-code coverage as complete when this is source that
+                // pytest-cov measured.
+                if (coverage.files[file.filename]) missingSourcePatches++;
+                continue;
+              }
               const lines = new Set();
               let newLine = 0;
               for (const line of file.patch.split('\n')) {
@@ -96,9 +103,11 @@ jobs:
             const percentage = (covered, total) => total
               ? `${(covered / total * 100).toFixed(2)}%`
               : 'N/A';
-            const addedCoverage = addedStatements
-              ? `${coveredAddedStatements} / ${addedStatements} (${percentage(coveredAddedStatements, addedStatements)})`
-              : 'N/A (no executable lines added)';
+            const addedCoverage = missingSourcePatches
+              ? `N/A (incomplete: GitHub omitted ${missingSourcePatches} source ${missingSourcePatches === 1 ? 'patch' : 'patches'})`
+              : addedStatements
+                ? `${coveredAddedStatements} / ${addedStatements} (${percentage(coveredAddedStatements, addedStatements)})`
+                : 'N/A (no executable lines added)';
             const branchCoverage = branches
               ? `${coveredBranches} / ${branches} (${percentage(coveredBranches, branches)})`
               : 'N/A';

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   test:
@@ -32,12 +31,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements/requirements.txt -r requirements/requirements-dev.txt
 
-      - name: Fetch pull request base
-        if: github.event_name == 'pull_request'
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: git fetch --no-tags --depth=1 origin "$BASE_SHA"
-
       - name: Run tests with coverage
         run: |
           python -m pytest \
@@ -46,99 +39,12 @@ jobs:
             --cov-report=term-missing \
             --cov-report=json:coverage.json
 
-      - name: Report coverage on pull request
+      # A separate workflow_run workflow consumes this as untrusted data. Keeping
+      # the write token out of this workflow lets coverage work safely for forks.
+      - name: Upload coverage report
         if: ${{ always() && github.event_name == 'pull_request' && hashFiles('coverage.json') != '' }}
-        continue-on-error: true
-        uses: actions/github-script@v8
+        uses: actions/upload-artifact@v6
         with:
-          script: |
-            const fs = require('fs');
-            const coverage = JSON.parse(fs.readFileSync('coverage.json', 'utf8'));
-            const totals = coverage.totals;
-            const marker = '<!-- pytest-coverage-report -->';
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const baseSha = context.payload.pull_request.base.sha;
-            const {stdout: diff} = await exec.getExecOutput(
-              'git', ['diff', '--unified=0', '--no-color', baseSha, 'HEAD']
-            );
-
-            // Collect new-side line numbers from each diff hunk. Coverage.py's
-            // executed/missing lists then tell us which added lines are statements.
-            const addedLines = new Map();
-            let path = null;
-            let newLine = 0;
-            for (const line of diff.split('\n')) {
-              if (line.startsWith('+++ b/')) {
-                path = line.slice(6);
-                if (!addedLines.has(path)) addedLines.set(path, new Set());
-              } else if (line.startsWith('+++ /dev/null')) {
-                path = null;
-              } else if (line.startsWith('@@')) {
-                const match = line.match(/\+(\d+)(?:,(\d+))?/);
-                if (match) newLine = Number(match[1]);
-              } else if (path && line.startsWith('+')) {
-                addedLines.get(path).add(newLine++);
-              } else if (path && !line.startsWith('-')) {
-                newLine++;
-              }
-            }
-
-            let addedStatements = 0;
-            let coveredAddedStatements = 0;
-            for (const [file, lines] of addedLines) {
-              const fileCoverage = coverage.files[file];
-              if (!fileCoverage) continue;
-              const executed = new Set(fileCoverage.executed_lines);
-              const missing = new Set(fileCoverage.missing_lines);
-              for (const line of lines) {
-                if (executed.has(line) || missing.has(line)) addedStatements++;
-                if (executed.has(line)) coveredAddedStatements++;
-              }
-            }
-
-            const addedCoverage = addedStatements
-              ? `${coveredAddedStatements} / ${addedStatements} (${(coveredAddedStatements / addedStatements * 100).toFixed(2)}%)`
-              : 'N/A (no executable lines added)';
-            const branchCoverage = totals.num_branches
-              ? `${totals.covered_branches} / ${totals.num_branches} (${(totals.covered_branches / totals.num_branches * 100).toFixed(2)}%)`
-              : 'N/A';
-            const body = [
-              marker,
-              '## 🧪 Unit test coverage',
-              '',
-              '| Metric | Result |',
-              '| --- | ---: |',
-              `| **New code lines** | **${addedCoverage}** |`,
-              `| All code lines | ${totals.covered_lines} / ${totals.num_statements} (${totals.percent_covered_display}%) |`,
-              `| All code missing lines | ${totals.missing_lines} |`,
-              `| All code branches | ${branchCoverage} |`,
-              '',
-              '> Coverage is currently informational only; no minimum threshold is enforced.',
-              '',
-              `[🔍 View workflow run](${runUrl})`,
-            ].join('\n');
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const previous = comments.find(comment =>
-              comment.user.type === 'Bot' && comment.body.includes(marker)
-            );
-
-            if (previous) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: previous.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+          name: coverage-report
+          path: coverage.json
+          retention-days: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   test:
@@ -31,5 +32,64 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements/requirements.txt -r requirements/requirements-dev.txt
 
-      - name: Run tests
-        run: python -m pytest
+      - name: Run tests with coverage
+        run: |
+          python -m pytest \
+            --cov=. \
+            --cov-branch \
+            --cov-report=term-missing \
+            --cov-report=json:coverage.json
+
+      - name: Report coverage on pull request
+        if: ${{ always() && github.event_name == 'pull_request' && hashFiles('coverage.json') != '' }}
+        continue-on-error: true
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const coverage = JSON.parse(fs.readFileSync('coverage.json', 'utf8'));
+            const totals = coverage.totals;
+            const marker = '<!-- pytest-coverage-report -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const branchCoverage = totals.num_branches
+              ? `${totals.covered_branches} / ${totals.num_branches} (${(totals.covered_branches / totals.num_branches * 100).toFixed(2)}%)`
+              : 'N/A';
+            const body = [
+              marker,
+              '## 🧪 Unit test coverage',
+              '',
+              '| Metric | Result |',
+              '| --- | ---: |',
+              `| Lines | ${totals.covered_lines} / ${totals.num_statements} (${totals.percent_covered_display}%) |`,
+              `| Missing lines | ${totals.missing_lines} |`,
+              `| Branches | ${branchCoverage} |`,
+              '',
+              '> Coverage is currently informational only; no minimum threshold is enforced.',
+              '',
+              `[🔍 View workflow run](${runUrl})`,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const previous = comments.find(comment =>
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            );
+
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previous.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements/requirements.txt -r requirements/requirements-dev.txt
 
+      - name: Fetch pull request base
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git fetch --no-tags --depth=1 origin "$BASE_SHA"
+
       - name: Run tests with coverage
         run: |
           python -m pytest \
@@ -51,6 +57,48 @@ jobs:
             const totals = coverage.totals;
             const marker = '<!-- pytest-coverage-report -->';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const baseSha = context.payload.pull_request.base.sha;
+            const {stdout: diff} = await exec.getExecOutput(
+              'git', ['diff', '--unified=0', '--no-color', baseSha, 'HEAD']
+            );
+
+            // Collect new-side line numbers from each diff hunk. Coverage.py's
+            // executed/missing lists then tell us which added lines are statements.
+            const addedLines = new Map();
+            let path = null;
+            let newLine = 0;
+            for (const line of diff.split('\n')) {
+              if (line.startsWith('+++ b/')) {
+                path = line.slice(6);
+                if (!addedLines.has(path)) addedLines.set(path, new Set());
+              } else if (line.startsWith('+++ /dev/null')) {
+                path = null;
+              } else if (line.startsWith('@@')) {
+                const match = line.match(/\+(\d+)(?:,(\d+))?/);
+                if (match) newLine = Number(match[1]);
+              } else if (path && line.startsWith('+')) {
+                addedLines.get(path).add(newLine++);
+              } else if (path && !line.startsWith('-')) {
+                newLine++;
+              }
+            }
+
+            let addedStatements = 0;
+            let coveredAddedStatements = 0;
+            for (const [file, lines] of addedLines) {
+              const fileCoverage = coverage.files[file];
+              if (!fileCoverage) continue;
+              const executed = new Set(fileCoverage.executed_lines);
+              const missing = new Set(fileCoverage.missing_lines);
+              for (const line of lines) {
+                if (executed.has(line) || missing.has(line)) addedStatements++;
+                if (executed.has(line)) coveredAddedStatements++;
+              }
+            }
+
+            const addedCoverage = addedStatements
+              ? `${coveredAddedStatements} / ${addedStatements} (${(coveredAddedStatements / addedStatements * 100).toFixed(2)}%)`
+              : 'N/A (no executable lines added)';
             const branchCoverage = totals.num_branches
               ? `${totals.covered_branches} / ${totals.num_branches} (${(totals.covered_branches / totals.num_branches * 100).toFixed(2)}%)`
               : 'N/A';
@@ -60,9 +108,10 @@ jobs:
               '',
               '| Metric | Result |',
               '| --- | ---: |',
-              `| Lines | ${totals.covered_lines} / ${totals.num_statements} (${totals.percent_covered_display}%) |`,
-              `| Missing lines | ${totals.missing_lines} |`,
-              `| Branches | ${branchCoverage} |`,
+              `| **New code lines** | **${addedCoverage}** |`,
+              `| All code lines | ${totals.covered_lines} / ${totals.num_statements} (${totals.percent_covered_display}%) |`,
+              `| All code missing lines | ${totals.missing_lines} |`,
+              `| All code branches | ${branchCoverage} |`,
               '',
               '> Coverage is currently informational only; no minimum threshold is enforced.',
               '',

--- a/poetry.lock
+++ b/poetry.lock
@@ -659,6 +659,110 @@ files = [
 markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
+name = "coverage"
+version = "7.15.3"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "coverage-7.15.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3a82b2ceee91ba353e59fe2436d8a9eae799ff9825e5385423ea205d693e2949"},
+    {file = "coverage-7.15.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3088cce65e54c2eefc08e7e1ca0b0acec1e95e8cf084ac848599103ed0367f74"},
+    {file = "coverage-7.15.3-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a65e09efb0b5ab21fc54a8a65c5b2e533c0a4c0d064af0259a005dc656dc1b13"},
+    {file = "coverage-7.15.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b51f279a2477b0e1f288b98f141fd227acfdd1d3f0370400e473788879b47871"},
+    {file = "coverage-7.15.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7835176988cbcf1f014db683bc33aa15e0558e412bf08deaa99757335b88df15"},
+    {file = "coverage-7.15.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f24896dc8863167f6732f4142f5d37e6195eccc8fe5fe528d35d49597d29fdb3"},
+    {file = "coverage-7.15.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9490d43e5d041fdf376770a886a29722adb05f6b9c21a65c48c81fc8f1c33fd7"},
+    {file = "coverage-7.15.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:225e359bd5dedaff6d68e36091af20555866c557d968167308b677379bf575c3"},
+    {file = "coverage-7.15.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:22119e2e3b2ac5ac024d50131fdd4b22ab4c6cf8aa2fc792cce73c0d94c5812d"},
+    {file = "coverage-7.15.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:12d555badc462b0f6037ce8bec8b4af8d71f90eb55b57d0a358731f7ee7883e2"},
+    {file = "coverage-7.15.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:c4e2cf9cf774939b3dc581c6e31dfe7e8d7608b24f0f17524d6161f8235c3d2c"},
+    {file = "coverage-7.15.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cea1b3e19d710f67e2ba9ce0b0b51032c2a9b4808a65ced48ddf336ef7e58058"},
+    {file = "coverage-7.15.3-cp310-cp310-win32.whl", hash = "sha256:25c77560309f157e7b7ee8fe0bf78d047ba900b7ae42f0e50e559305b366fea2"},
+    {file = "coverage-7.15.3-cp310-cp310-win_amd64.whl", hash = "sha256:179fbf847e6c3d90ea71bfd570fe57f1ddb1c51474754894871c1e11099efaa0"},
+    {file = "coverage-7.15.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5f3f854ab4599d98f7799ac9b91e34e8ec9ebc9a6372ee8c1f3413a68cc8b5e9"},
+    {file = "coverage-7.15.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:75268348fee1f199653b8a846262aec5581c6bb008c4f58824959fb708cc688f"},
+    {file = "coverage-7.15.3-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:21081739f6264cc594cad2d42b62befbd17633824022866c68720eb0c4b8d6b4"},
+    {file = "coverage-7.15.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:718d366251b060c10731c7dd359de6caea72250036eb94576aa56dacbf830a11"},
+    {file = "coverage-7.15.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fa1bbaa502a6e877f3ee67cbac3eba2bb637f623e454e6c37b81b38896dbd48f"},
+    {file = "coverage-7.15.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:494880c9e60782610683f4eb9b65cce4f886673596b8f3cb2dfa079fc551c743"},
+    {file = "coverage-7.15.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3db264ea689f9e8f9fa4fb9005fee4048c3bff4a547f4cfa27f5086cb0804ec0"},
+    {file = "coverage-7.15.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4e869d4799674d67778e76ddbe2e26cf1673369262e231a8ec259421b1015fea"},
+    {file = "coverage-7.15.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:696fc7a28bbf717aba8d2c6963d26702945c7832cb313ba3b323aa5b1afb3156"},
+    {file = "coverage-7.15.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:3fe9be1c527497d047f770d88a0110189714c36383bb88384508f750c302bffa"},
+    {file = "coverage-7.15.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2400591f4b2e33746c70846388f8bb4c7e33b820e31cb8c6cb2f25305310438b"},
+    {file = "coverage-7.15.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2e557178799282269412a672e5753f2179edfe1b3f0f19b0c98f8e72d482326a"},
+    {file = "coverage-7.15.3-cp311-cp311-win32.whl", hash = "sha256:68ea6c947375982ae907e19e9d2ef156bd6e68e11f3566dd568d7f4ec974e715"},
+    {file = "coverage-7.15.3-cp311-cp311-win_amd64.whl", hash = "sha256:28743dad31622e8c474b17446118037361f5b1f4f2ecdf72d4f6fde246d64446"},
+    {file = "coverage-7.15.3-cp311-cp311-win_arm64.whl", hash = "sha256:c4398918c4fda32718191239e451fd86ac5ad1e8979b592f1921ee2d1f038965"},
+    {file = "coverage-7.15.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:79a3e32e83227d83d9684459ed579769b56c369ac2d7313099b2d9e031d2e10f"},
+    {file = "coverage-7.15.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:767feb87c5886d781d0a69fafd450a20826ddab7b79bce1665deb64d21441b60"},
+    {file = "coverage-7.15.3-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:50951e37033c40548d777b8a8454a2cd622dba1136780065678dccaec307c47f"},
+    {file = "coverage-7.15.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:63a4ff67364afb2cac826b8bbd78a5c50ce656a7b7137436b44d7b96a9271088"},
+    {file = "coverage-7.15.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e95e42856509675fe26560310313a6117640e96f9a1e19bb3d220116a27c94c"},
+    {file = "coverage-7.15.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:abad631cba27094b4631993f4c72e89ac0ca1b3a0236c7abaf8ca79aea619851"},
+    {file = "coverage-7.15.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2b0807f1f051dd82a234ad6acdb6f1425baede60be1e84e862496c8cc9262ab9"},
+    {file = "coverage-7.15.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d8d6df7aeb5bc464040bbc9ae173d875785d3677ebc4307817997d622d74225e"},
+    {file = "coverage-7.15.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:974471c506c9f5758808b47c1ebf7949ecd0848f5c1020e78675fefe5ff46866"},
+    {file = "coverage-7.15.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5cba0c9c13e35c86df7998f1afaf6b1da224a3a39e4da59bdabf60c148046dcb"},
+    {file = "coverage-7.15.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:4d608dc36a364dce33acbf4fc3a50f9d2054c945f233bb0a2cdb4b90bfa17646"},
+    {file = "coverage-7.15.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2395869280554a1941da904423c12660c39f721315e1c02d076a7fe0971382f0"},
+    {file = "coverage-7.15.3-cp312-cp312-win32.whl", hash = "sha256:24f3b21840c3eb76cef3cc70b2bf6649010c64471a84a446538a39306e1ba04d"},
+    {file = "coverage-7.15.3-cp312-cp312-win_amd64.whl", hash = "sha256:fa7b17902c3c1dd8a7adb52679b7f6340bba08443d710c8838e04db8cf62be2a"},
+    {file = "coverage-7.15.3-cp312-cp312-win_arm64.whl", hash = "sha256:fcbe83fb7258eacd293bf5322d88807acb35ed12a5cfa99dd8215c083e3b0235"},
+    {file = "coverage-7.15.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1182eed05674c63d40951fae27c43e822749f04d25f75df64c2e4fa3168678de"},
+    {file = "coverage-7.15.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c0c4b0d7c4cd56e470d0c9d8441f42e8a96cdfd95050fec027f1d4dd9f11006c"},
+    {file = "coverage-7.15.3-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5c9fce9f4998b0d50a753da765b9215a14decc7863822c89d72da7a89ca625b3"},
+    {file = "coverage-7.15.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7a47e2a0a0ace9241e70ee00e44520f88b843094603dd54303f1bafecd929c30"},
+    {file = "coverage-7.15.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95bad94f83807ae60ed76f3ac012f69b2605ac9ea81bee959a5a483f7fa09c10"},
+    {file = "coverage-7.15.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:228e172a76c428bb17d1ab78a2ff188990b0597e5dbd291f52a4edf7412de049"},
+    {file = "coverage-7.15.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cea9fb33887c99349996266f1fd60abe5af3577a90633392001d27ef46b4b66e"},
+    {file = "coverage-7.15.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:81760de3155d7f52c21860c4046628dc6bed182f72e3c028e2b4fd46f65aa040"},
+    {file = "coverage-7.15.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b47ea0a1d3a3d089826c6cbfad8429d7d8872e28e86baa95ddef330f6875da21"},
+    {file = "coverage-7.15.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5459ba486b2a5d58a6c05254779ecdf525e7f20174d0210ceda75ba40fdb8f2c"},
+    {file = "coverage-7.15.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c59209f80a08dbfcdd5109a80dc623cd3b9d22895c85757d34f57a6e6e95570f"},
+    {file = "coverage-7.15.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f863856c1779d4a5bb6a94698a2f9073e09c6706501f76f3e7780e72df97d21c"},
+    {file = "coverage-7.15.3-cp313-cp313-win32.whl", hash = "sha256:00cbdc5e322927dc30c5e42b863819b1bb867cc66f26ab5372c585850876ab93"},
+    {file = "coverage-7.15.3-cp313-cp313-win_amd64.whl", hash = "sha256:835528518a1d823cf336740324b2f335f7c01e609e74abcb5d5163b3e66661e3"},
+    {file = "coverage-7.15.3-cp313-cp313-win_arm64.whl", hash = "sha256:0d2e1f2cbbf36b842f3e2aff8d118c60d677adb498bc6c7fa9c6838738f82767"},
+    {file = "coverage-7.15.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1e3bb08ad574bd9fb6a991f645728f70d333c1c1958dd5fcde65e24cb862813d"},
+    {file = "coverage-7.15.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9e5860eaff02a0b7f1b73304bdf846596ee62ab3a78d25c68044ebf684cb1fef"},
+    {file = "coverage-7.15.3-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:60874e5bd67f0b1bdbe42ab42c7bafa66a6fb8de88721af6df3f7a02713960cd"},
+    {file = "coverage-7.15.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f9147be876e9d83765e0b82176674dc248a6b9283e25e01e7462611b97e9b731"},
+    {file = "coverage-7.15.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61a01f8c3804760fcc5a3d31c4f3cab792d660d44e17bf7adeaf0ea51e07821e"},
+    {file = "coverage-7.15.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:95bf3e7f26f792e25eb185f85a5a659d48479265176dcfe22b6f334fd0081b5c"},
+    {file = "coverage-7.15.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:44c41eff9e413fed8740eca75d5438ebeb9d3e45e7cd37c67329213e7a72c764"},
+    {file = "coverage-7.15.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54146bafb61f3ba9895b43af0dd17eba01561d586d44ce84ea221b0cbbee5a9e"},
+    {file = "coverage-7.15.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:af000dd1bb859ff8066fda4c79512ff938c798116540307226b373099c7b151f"},
+    {file = "coverage-7.15.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a1b82490577f3889950b5a04f18712aef0207243e0749d60fe28c3c73ebfd5fd"},
+    {file = "coverage-7.15.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:c4fc90a60154c3e4b8a2dc206d6dbe852f1c235c249e0dc0cef909d032c9591a"},
+    {file = "coverage-7.15.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f25bb884814a892948b4c20394db3f2364dd452d9492736479e7a493e63b0eb6"},
+    {file = "coverage-7.15.3-cp314-cp314-win32.whl", hash = "sha256:722dbf8e7828fbcfe0dc8586167dc0a5ce85ad6ea171dbb21ed3f8d6581d3cb8"},
+    {file = "coverage-7.15.3-cp314-cp314-win_amd64.whl", hash = "sha256:64d0845f9c3ed47302bed265c15ab4dbb64aa4ec1490839b8e328f4e7fa914d2"},
+    {file = "coverage-7.15.3-cp314-cp314-win_arm64.whl", hash = "sha256:69bc14684f8fbbee9f9dbaa4fe79719b0da9725fc37956785c06ec365acf6926"},
+    {file = "coverage-7.15.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f92df943c24b96cb215ca26b4f6a2283e63c5db80f1635aceea7fff11311917b"},
+    {file = "coverage-7.15.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:66591c46bdd2971d3ae2bc503a5f0459c2edcaf6b7e045b292000cc95bc6cb95"},
+    {file = "coverage-7.15.3-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa64458b81b18bfc67cdf1f6dc02b23e3edc672f2f8e11771fad75865415a43"},
+    {file = "coverage-7.15.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:447f5421ccf5475956cf516d4ca1d575f487947b6f4e11f9d80c6aefe24b3dc8"},
+    {file = "coverage-7.15.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a0c77ef8cd483a4987a5d12d1d9d5f7ee598dfdc6c0844417d847e5768dc779"},
+    {file = "coverage-7.15.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0b273f4ff657446a06c2d85bf80e134fa869a92852ba5f87854a70e1fb44da77"},
+    {file = "coverage-7.15.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daea8c4fafa22488600405be2c2be525a9406fba3fc0a83acc726db3e14e2005"},
+    {file = "coverage-7.15.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:93ff57c530f3fa7aa69f92fb9b8892b8aa82712aa970842f4abf28657f42fb57"},
+    {file = "coverage-7.15.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:4df21bef8b800eebda9018f53d49c9ace3aeb0090c850139b27923aafcb83e91"},
+    {file = "coverage-7.15.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:db567b02685f26034adcbd85055f80d12cdf02111b8ed00886093d98b2874ce2"},
+    {file = "coverage-7.15.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5318dd51b8600b947e058cf5a4fe54d183d9d13c49b97b64ca7be05a34df9bef"},
+    {file = "coverage-7.15.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c995bfa383c54704839b6c4c2627a1c00895597ada0e5e8190c81d8bd620555c"},
+    {file = "coverage-7.15.3-cp314-cp314t-win32.whl", hash = "sha256:6433fafb8da0e1d02eb53411e0ecdadb6b88f0224fdc23317e703c0e88937d42"},
+    {file = "coverage-7.15.3-cp314-cp314t-win_amd64.whl", hash = "sha256:fe578952b1b29fe8c777f43f241d49efac4b56724a3434f5d22ebe3c208df429"},
+    {file = "coverage-7.15.3-cp314-cp314t-win_arm64.whl", hash = "sha256:d2e1acb7aee29dfa8f3e48c23f36670898baca1209d9bdd3985a50c7f982165e"},
+    {file = "coverage-7.15.3-py3-none-any.whl", hash = "sha256:da78fa6fc7dafe4212839173133ee85afcf42c5cd5f3e47fa7c1c210453b445e"},
+    {file = "coverage-7.15.3.tar.gz", hash = "sha256:ae7ea5a4614acf399ef0483c4cb34f8f8f01df848d8fcbe7d3ce0865733f1c4d"},
+]
+
+[package.extras]
+toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
+
+[[package]]
 name = "cryptography"
 version = "50.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
@@ -1823,6 +1927,26 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)", "sphinx-tabs (>=3.5)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+description = "Pytest plugin for measuring coverage."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678"},
+    {file = "pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2"},
+]
+
+[package.dependencies]
+coverage = {version = ">=7.10.6", extras = ["toml"]}
+pluggy = ">=1.2"
+pytest = ">=7"
+
+[package.extras]
+testing = ["process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -2308,4 +2432,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "0096a23f8d43c4bc3b8baa379c8d22d686022e651c6bec5fa9a85db9189fd865"
+content-hash = "50686ec944a77775e4bfdd15a739f1060d382ca4770f6b6e62765cf9ba40ef9f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,9 @@ addopts = "-q"
 [dependency-groups]
 dev = [
     "pytest (>=9.1.1,<10.0.0)",
-    "pytest-asyncio (>=1.4.0,<2.0.0)"
+    "pytest-asyncio (>=1.4.0,<2.0.0)",
+    "pytest-cov (>=7.0.0,<8.0.0)"
 ]
+
+[tool.coverage.run]
+omit = ["tests/*"]

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest==9.1.1
 pytest-asyncio==1.4.0
+pytest-cov==7.1.0


### PR DESCRIPTION
### Motivation

- 在 CI 中收集并对外展示单元测试的行/分支覆盖率，以便在 Pull Request 中直观查看当前覆盖率状况而不强制门槛。

### Description

- 在 `.github/workflows/test.yml` 中把测试替换为带覆盖率收集的 pytest 调用，输出终端报告并生成 `coverage.json`，并新增一个步骤在 PR 中创建或更新带有覆盖率摘要的评论（使用 `actions/github-script`）。
- 为该覆盖率上报步骤添加了条件与 `continue-on-error: true`，并授予工作流写评论所需的 `pull-requests: write` 权限以避免阻塞 CI。  
- 将 `pytest-cov` 纳入开发依赖（同步更新了 `pyproject.toml` 的 dev 依赖组和 `requirements/requirements-dev.txt`），并更新了 `poetry.lock`；同时在 `pyproject.toml` 中添加了 `[tool.coverage.run]` 配置以排除 `tests/*`。

### Testing

- 执行 `poetry run python -m pytest --cov=. --cov-branch --cov-report=term-missing --cov-report=json:coverage.json`，测试通过且写出了 `coverage.json`（结果：81 passed，项目总体覆盖率约 35%）。
- 用 `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/test.yml')"` 验证了 workflow YAML 的语法正确性。 
- 运行 `poetry check --lock`，校验通过（输出包含现有的 Poetry 配置警告但不影响结果）。
- 对工作流上报步骤设置 `continue-on-error` 以保证评论上报失败不会导致 CI 失败。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a745707c260832f98db9ae281b67b08)