### PR TITLE
test: expand coverage for services and utilities

### DIFF
--- a/tests/test_command_history.py
+++ b/tests/test_command_history.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services import command_history
+
+
+def test_safe_truncate():
+    assert command_history._safe_truncate(None) is None
+    assert command_history._safe_truncate("short", 10) == "short"
+    assert command_history._safe_truncate("abcdef", 4) == "abc…"
+
+
+@pytest.mark.asyncio
+async def test_command_logger_records_success(monkeypatch):
+    record = AsyncMock()
+    monkeypatch.setattr(command_history.command_history_registry, "record_command_execution", record)
+    update = SimpleNamespace(
+        effective_message=SimpleNamespace(text="/ping one", message_id=7),
+        effective_chat=SimpleNamespace(id=-10, type="group"),
+        effective_user=SimpleNamespace(id=20),
+    )
+    context = SimpleNamespace(args=["one"])
+
+    @command_history.command_logger("ping")
+    async def handler(update, context):
+        return "pong"
+
+    assert handler.__command_name__ == "ping"
+    assert await handler(update, context) == "pong"
+    values = record.await_args.kwargs
+    assert values["duration_ms"] >= 0
+    assert values["triggered_at"].tzinfo is not None
+    assert values["command"] == "ping"
+    assert values["user_id"] == 20
+    assert values["chat_id"] == -10
+    assert values["arguments"] == ["one"]
+    assert values["success"] is True
+    assert values["error_message"] is None
+
+
+@pytest.mark.asyncio
+async def test_command_logger_reraises_and_records_failure(monkeypatch):
+    record = AsyncMock()
+    monkeypatch.setattr(command_history.command_history_registry, "record_command_execution", record)
+    update = SimpleNamespace(effective_message=None, effective_chat=None, effective_user=None)
+
+    @command_history.command_logger("fail")
+    async def handler(update, context):
+        raise RuntimeError("x" * 600)
+
+    with pytest.raises(RuntimeError):
+        await handler(update, SimpleNamespace())
+    values = record.await_args.kwargs
+    assert values["success"] is False
+    assert values["user_id"] is None
+    assert values["raw_text"] is None
+    assert len(values["error_message"]) == 500
+    assert values["error_message"].endswith("…")

--- a/tests/test_original_image_manager.py
+++ b/tests/test_original_image_manager.py
@@ -1,0 +1,63 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.error import BadRequest
+
+from services import original_image_manager as manager
+
+
+@pytest.fixture(autouse=True)
+def clear_registry():
+    manager._requests.clear()
+    manager._latest_token_by_chat.clear()
+
+
+def test_request_labels_and_markup():
+    request = manager.OriginalImageRequest("tok", 1, 2, 3, 4)
+    assert request.button_label() == "获取原图"
+    request.attempts = 1
+    assert "1/3" in request.button_label()
+    request.status = "fetching"
+    assert request.button_label() == "原图获取中"
+    request.status = "success"
+    assert request.build_markup().inline_keyboard[0][0].callback_data == "orig:tok"
+    request.status = "exhausted"
+    assert request.button_label() == "原图获取失败"
+
+
+@pytest.mark.asyncio
+async def test_register_replaces_previous_request_and_removes_markup(monkeypatch):
+    monkeypatch.setattr(manager.secrets, "token_hex", lambda _: "generated")
+    first = manager.OriginalImageRequest("first", 1, 2, 3, 4, message_id=10)
+    second = manager.create_request(1, 2, 5, 0)
+    second.message_id = 11
+    bot = AsyncMock()
+
+    await manager.register_request(bot, first)
+    await manager.register_request(bot, second)
+
+    assert second.token == "generated"
+    assert await manager.get_request("first") is None
+    assert await manager.get_request("generated") is second
+    assert await manager.is_request_active(second)
+    bot.edit_message_reply_markup.assert_awaited_once_with(chat_id=1, message_id=10, reply_markup=None)
+
+
+@pytest.mark.asyncio
+async def test_register_requires_message_id():
+    with pytest.raises(ValueError):
+        await manager.register_request(AsyncMock(), manager.create_request(1, 2, 3, 4))
+
+
+@pytest.mark.asyncio
+async def test_update_markup_ignores_inactive_and_telegram_errors():
+    bot = AsyncMock()
+    inactive = manager.OriginalImageRequest("inactive", 1, 2, 3, 4, message_id=10)
+    await manager.update_markup(bot, inactive)
+    bot.edit_message_reply_markup.assert_not_awaited()
+
+    await manager.register_request(bot, inactive)
+    bot.reset_mock()
+    bot.edit_message_reply_markup.side_effect = BadRequest("gone")
+    await manager.update_markup(bot, inactive)
+    bot.edit_message_reply_markup.assert_awaited_once()

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,32 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services import permissions
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, set()),
+        (False, set()),
+        (True, set()),
+        ("1, 2\n3\tinvalid 2", {1, 2, 3}),
+        ("", set()),
+    ],
+)
+def test_parse_super_user_ids(value, expected):
+    assert permissions._parse_super_user_ids(value) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("configured", "user_id", "expected"),
+    [("10,20", 20, True), ("10,20", 30, False), ("10", None, False), (None, None, True)],
+)
+async def test_has_super_user_access(monkeypatch, configured, user_id, expected):
+    get_config = AsyncMock(return_value=configured)
+    monkeypatch.setattr(permissions.config_registry, "get_config", get_config)
+
+    assert await permissions.has_super_user_access(user_id) is expected
+    get_config.assert_awaited_once_with("super_user")

--- a/tests/test_service_helpers.py
+++ b/tests/test_service_helpers.py
@@ -1,0 +1,151 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from telegram.error import BadRequest
+
+from services import command_history
+from services import group_guard
+from services import original_image_manager as original_images
+from services.file_service import file_lock
+from services.schema_migrator import (
+    _ensure_column_bigint,
+    _get_current_version,
+    _record_migration,
+)
+from services.storage_service.local import LocalStorage
+
+
+@pytest.mark.asyncio
+async def test_local_storage_loads_config_and_uploads_to_nested_folder(tmp_path, monkeypatch):
+    config = SimpleNamespace(root_path=str(tmp_path), base_url="https://cdn.example/files/")
+    get_config = AsyncMock(return_value=config)
+    monkeypatch.setattr(
+        "services.storage_service.local.config_registry.get_local_storage_config",
+        get_config,
+    )
+    storage = LocalStorage()
+
+    url = await storage.upload(b"image-data", "sample.jpg", r"pixiv\2026")
+
+    assert url == "https://cdn.example/files/pixiv/2026/sample.jpg"
+    assert (tmp_path / "pixiv" / "2026" / "sample.jpg").read_bytes() == b"image-data"
+    get_config.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_local_storage_returns_relative_path_without_base_url(tmp_path, monkeypatch):
+    config = SimpleNamespace(root_path=str(tmp_path), base_url=None)
+    monkeypatch.setattr(
+        "services.storage_service.local.config_registry.get_local_storage_config",
+        AsyncMock(return_value=config),
+    )
+    storage = LocalStorage()
+
+    assert await storage.upload(b"x", "file.bin") == "file.bin"
+
+
+def test_file_locks_are_reused_and_can_be_deleted():
+    file_lock.file_locks.clear()
+    dictionary_lock, first = file_lock.get_lock("one")
+    assert dictionary_lock is file_lock.get_dick_lock()
+    assert file_lock.get_lock("one")[1] is first
+
+    file_lock.del_lock("one")
+    assert file_lock.get_lock("one")[1] is not first
+
+
+@pytest.mark.asyncio
+async def test_keyword_rule_rejects_empty_long_and_invalid_regex_without_database_access(
+    monkeypatch,
+):
+    new_session = MagicMock()
+    monkeypatch.setattr(group_guard.engine, "new_session", new_session)
+
+    with pytest.raises(ValueError, match="不能为空"):
+        await group_guard.add_keyword_rule(1, "   ")
+    with pytest.raises(ValueError, match="长度不能超过"):
+        await group_guard.add_keyword_rule(1, "x" * (group_guard.MAX_KEYWORD_PATTERN_LENGTH + 1))
+    with pytest.raises(ValueError, match="正则表达式无效"):
+        await group_guard.add_keyword_rule(1, "[", is_regex=True)
+
+    new_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_guard_cache_invalidation_and_empty_ensure_settings(monkeypatch):
+    settings = group_guard.GuardSettings(1, True, 60, None, False, True)
+    group_guard._settings_cache[1] = (settings, datetime.now(timezone.utc))
+    group_guard._keyword_cache[1] = ([], datetime.now(timezone.utc))
+
+    await group_guard._invalidate_settings_cache(1)
+    await group_guard._invalidate_keyword_cache(1)
+    assert 1 not in group_guard._settings_cache
+    assert 1 not in group_guard._keyword_cache
+
+    new_session = MagicMock()
+    monkeypatch.setattr(group_guard.engine, "new_session", new_session)
+    await group_guard.ensure_settings([0, 0])
+    new_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_schema_helpers_select_version_and_use_dialect_specific_upsert():
+    result = MagicMock()
+    result.scalar.return_value = None
+    connection = AsyncMock()
+    connection.execute.return_value = result
+    connection.dialect.name = "sqlite"
+
+    assert await _get_current_version(connection, "schema_migrations") == 0
+    await _record_migration(connection, "schema_migrations", 2)
+    statement, parameters = connection.execute.await_args_list[-1].args
+    assert "ON CONFLICT(version)" in str(statement)
+    assert parameters == {"version": 2}
+
+    connection.dialect.name = "mysql"
+    await _record_migration(connection, "schema_migrations", 3)
+    statement = connection.execute.await_args_list[-1].args[0]
+    assert "ON DUPLICATE KEY" in str(statement)
+
+
+@pytest.mark.asyncio
+async def test_ensure_column_bigint_skips_missing_or_already_compatible_columns():
+    connection = AsyncMock()
+    result = MagicMock()
+    result.mappings.return_value.first.return_value = None
+    connection.execute.return_value = result
+    await _ensure_column_bigint(connection, "db", "users", "id", allow_autoincrement=False)
+    assert connection.execute.await_count == 1
+
+    result.mappings.return_value.first.return_value = {
+        "DATA_TYPE": "bigint",
+        "IS_NULLABLE": "NO",
+        "COLUMN_DEFAULT": None,
+        "COLUMN_COMMENT": None,
+        "EXTRA": "",
+    }
+    await _ensure_column_bigint(connection, "db", "users", "id", allow_autoincrement=False)
+    assert connection.execute.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_history_and_markup_failures_are_best_effort(monkeypatch):
+    monkeypatch.setattr(command_history, "_persist_history", AsyncMock(side_effect=RuntimeError("db")))
+
+    @command_history.command_logger("ping")
+    async def handler(update, context):
+        return "pong"
+
+    assert await handler(SimpleNamespace(), SimpleNamespace()) == "pong"
+
+    original_images._requests.clear()
+    original_images._latest_token_by_chat.clear()
+    previous = original_images.OriginalImageRequest("old", 1, 2, 3, 0, message_id=10)
+    current = original_images.OriginalImageRequest("new", 1, 2, 4, 0, message_id=11)
+    bot = AsyncMock()
+    await original_images.register_request(bot, previous)
+    bot.edit_message_reply_markup.side_effect = BadRequest("gone")
+    await original_images.register_request(bot, current)
+    assert await original_images.get_request("new") is current

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from telegram import Chat
+
+from services.group_guard import PendingVerification, _ensure_timezone, generate_token
+from services.schema_migrator import _build_comment_clause, _build_default_clause, _quote
+from services.storage_service.Storage import Storage
+from utils.is_group_type import is_group_type
+from utils.list_utils import ensure_list_length
+
+
+def test_ensure_list_length_mutates_lists_and_pads_tuples():
+    original = [1]
+    assert ensure_list_length(original, 3) is original
+    assert original == [1, None, None]
+    assert ensure_list_length((1, 2, 3), 2) == [1, 2]
+    assert ensure_list_length(object(), 2) == [None, None]
+
+
+@pytest.mark.parametrize("chat_type", [Chat.GROUP, Chat.SUPERGROUP])
+def test_is_group_type(chat_type):
+    assert is_group_type(chat_type) is True
+
+
+def test_private_chat_is_not_group():
+    assert is_group_type(Chat.PRIVATE) is False
+
+
+def test_storage_path_helpers():
+    assert Storage.normalize_sub_folder(r"/foo\bar/") == "foo/bar/"
+    assert Storage.join_path("/root/", "", r"child\file") == "root/child/file"
+
+
+def test_schema_sql_helpers_escape_values_and_reject_identifiers():
+    assert _quote("safe_table_1") == "`safe_table_1`"
+    with pytest.raises(ValueError):
+        _quote("users; DROP TABLE users")
+    assert _build_default_clause(None) == ""
+    assert _build_default_clause(b"abc") == " DEFAULT 'abc'"
+    assert _build_default_clause("NULL") == " DEFAULT NULL"
+    assert _build_default_clause("it's") == " DEFAULT 'it''s'"
+    assert _build_default_clause(3) == " DEFAULT 3"
+    assert _build_comment_clause(None) == ""
+    assert _build_comment_clause("owner's") == " COMMENT 'owner''s'"
+
+
+def test_pending_verification_expiry_handles_naive_datetimes():
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    pending = PendingVerification(1, 2, None, "token", datetime(2026, 1, 1))
+    assert pending.is_expired(now=now)
+    assert _ensure_timezone(now.astimezone(timezone(timedelta(hours=8)))) == now
+
+
+def test_generate_token_uses_requested_length_and_alphanumeric_characters():
+    token = generate_token(24)
+    assert len(token) == 24
+    assert token.isalnum()


### PR DESCRIPTION
### Motivation
- Improve automated test coverage for core services and utility helpers to catch regressions and document expected behaviors.
- Exercise edge cases in permission parsing, command-history recording, original-image request lifecycle, and storage/schema helper utilities.

### Description
- Add tests for super-user parsing and access logic in `services.permissions` (`tests/test_permissions.py`).
- Add tests for the `command_logger` decorator and `_safe_truncate` behavior in `services.command_history` (`tests/test_command_history.py`).
- Add tests for `OriginalImageRequest` lifecycle, registry behavior, and Telegram error handling in `services.original_image_manager` (`tests/test_original_image_manager.py`).
- Add tests for list utilities, group-type detection, storage path helpers, schema SQL helpers, timezone handling and token generation in various utilities (`tests/test_utilities.py`).
- Small adjustment to assertions in `tests/test_command_history.py` to assert `duration_ms` non-negativity and that `triggered_at` is timezone-aware.

### Testing
- Ran the test suite with `python -m pytest -o addopts='' -q`, and all tests passed.
- Ran coverage for the changed modules with `python -m pytest --cov=services.permissions --cov=services.command_history --cov=services.group_guard --cov=services.original_image_manager --cov=services.schema_migrator --cov=services.storage_service.Storage --cov=utils --cov-report=term-missing -q`, and the coverage run completed successfully.
- Code consistency checks were executed and reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a752b554000832f92089db3453b134c)