### PR TITLE
CI: emit per-test-type coverage reports and add breakdown to PR comment

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -34,7 +34,16 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const coverage = JSON.parse(fs.readFileSync('coverage-artifact/coverage.json', 'utf8'));
+            const readCoverage = file => JSON.parse(
+              fs.readFileSync(`coverage-artifact/${file}`, 'utf8')
+            );
+            const coverage = readCoverage('coverage.json');
+            const coverageByType = [
+              ['Unit', readCoverage('coverage-unit.json')],
+              ['Service', readCoverage('coverage-service.json')],
+              ['System', readCoverage('coverage-system.json')],
+              ['E2E', readCoverage('coverage-e2e.json')],
+            ];
             const totals = coverage.totals;
             const pr = context.payload.workflow_run.pull_requests[0];
             const number = pr.number;
@@ -103,6 +112,14 @@ jobs:
             const percentage = (covered, total) => total
               ? `${(covered / total * 100).toFixed(2)}%`
               : 'N/A';
+            const coverageRow = ([name, report]) => {
+              const typeTotals = report.totals;
+              const typeCoveredLines = integer(typeTotals.covered_lines);
+              const typeStatements = integer(typeTotals.num_statements);
+              const typeCoveredBranches = integer(typeTotals.covered_branches);
+              const typeBranches = integer(typeTotals.num_branches);
+              return `| ${name} | ${typeCoveredLines} / ${typeStatements} (${percentage(typeCoveredLines, typeStatements)}) | ${typeCoveredBranches} / ${typeBranches} (${percentage(typeCoveredBranches, typeBranches)}) |`;
+            };
             const addedCoverage = missingSourcePatches
               ? `N/A (incomplete: GitHub omitted ${missingSourcePatches} source ${missingSourcePatches === 1 ? 'patch' : 'patches'})`
               : addedStatements
@@ -123,6 +140,12 @@ jobs:
               `| All code lines | ${coveredLines} / ${statements} (${percentage(coveredLines, statements)}) |`,
               `| All code missing lines | ${missingLines} |`,
               `| All code branches | ${branchCoverage} |`,
+              '',
+              '### Coverage by test type',
+              '',
+              '| Test type | Lines | Branches |',
+              '| --- | ---: | ---: |',
+              ...coverageByType.map(coverageRow),
               '',
               '> Coverage is currently informational only; no minimum threshold is enforced.',
               '',

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,12 +44,7 @@ jobs:
           }
 
           run_tests unit tests/unit
-          run_tests service \
-            tests/test_command_history.py \
-            tests/test_original_image_manager.py \
-            tests/test_permissions.py \
-            tests/test_service_helpers.py \
-            tests/test_utilities.py
+          run_tests service tests/test_*.py
           run_tests system tests/system
           run_tests e2e tests/e2e
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,20 +31,42 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements/requirements.txt -r requirements/requirements-dev.txt
 
-      - name: Run tests with coverage
+      - name: Run tests with coverage by test type
         run: |
-          python -m pytest \
-            --cov=. \
-            --cov-branch \
-            --cov-report=term-missing \
-            --cov-report=json:coverage.json
+          run_tests() {
+            test_type="$1"
+            shift
+            COVERAGE_FILE=".coverage.${test_type}" python -m pytest "$@" \
+              --cov=. \
+              --cov-branch \
+              --cov-report=term-missing \
+              --cov-report="json:coverage-${test_type}.json"
+          }
+
+          run_tests unit tests/unit
+          run_tests service \
+            tests/test_command_history.py \
+            tests/test_original_image_manager.py \
+            tests/test_permissions.py \
+            tests/test_service_helpers.py \
+            tests/test_utilities.py
+          run_tests system tests/system
+          run_tests e2e tests/e2e
+
+          python -m coverage combine \
+            .coverage.unit \
+            .coverage.service \
+            .coverage.system \
+            .coverage.e2e
+          python -m coverage report --show-missing
+          python -m coverage json -o coverage.json
 
       # A separate workflow_run workflow consumes this as untrusted data. Keeping
       # the write token out of this workflow lets coverage work safely for forks.
-      - name: Upload coverage report
-        if: ${{ always() && github.event_name == 'pull_request' && hashFiles('coverage.json') != '' }}
+      - name: Upload coverage reports
+        if: ${{ always() && github.event_name == 'pull_request' && hashFiles('coverage*.json') != '' }}
         uses: actions/upload-artifact@v6
         with:
           name: coverage-report
-          path: coverage.json
+          path: coverage*.json
           retention-days: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,5 @@ dev = [
 
 [tool.coverage.run]
 omit = ["tests/*"]
+patch = ["subprocess"]
+sigterm = true


### PR DESCRIPTION
### Motivation

- Provide granular coverage metrics for different test types (Unit, Service, System, E2E) so PRs show where coverage comes from.
- Produce per-type coverage JSON artifacts and a combined overall report to improve visibility and diagnostics.

### Description

- Update `test.yml` to run `pytest` separately for `unit`, `service`, `system`, and `e2e` test groups while writing per-type coverage files (`coverage-unit.json`, `coverage-service.json`, `coverage-system.json`, `coverage-e2e.json`), then combine them with `coverage combine` and emit `coverage.json`.
- Change artifact upload to include all `coverage*.json` files and guard the step with `hashFiles('coverage*.json') != ''`.
- Update `coverage-report.yml` to download the artifact set and read each per-type JSON via a `readCoverage` helper, and add a "Coverage by test type" table into the PR comment showing lines and branch coverage per test type.
- Keep handling to skip stale runs and avoid executing/interpolating artifact contents, and preserve the overall coverage summary and added-lines coverage calculation.

### Testing

- The CI `test` job is configured to run `pytest` for `unit`, `service`, `system`, and `e2e` groups, run `python -m coverage combine`, and produce `coverage.json` and per-type JSON files as artifacts; the `coverage-report` job runs on successful workflow runs and posts the new comment.
- No automated CI run results are included in this change, so no test success/failure results are reported in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a759fe3ca98832fb5e8678a6efae7ba)