### PR TITLE
refactor: migrate admin WebUI to native Vuetify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ logs/
 
 # Vite 临时文件
 webui/*.timestamp-*.mjs
+
+# TypeScript/Vite config build outputs
+/webui/vite.config.js
+/webui/vite.config.d.ts
+/webui/tsconfig.tsbuildinfo
+/webui/tsconfig.node.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ACG 图像 Bot 管理端
 
-该项目提供 FastAPI 后端与基于 PrimeVue 的管理控制台。要在本地运行完整的控制台体验，请按以下步骤操作：
+该项目提供 FastAPI 后端与基于 Vuetify（Material 3）的管理控制台。要在本地运行完整的控制台体验，请按以下步骤操作：
 
 1. 安装 Python 依赖并启动 FastAPI 后端：
    ```bash
-   uvicorn main:app --reload
+   uvicorn main:app
    ```
 2. 安装前端依赖并启动开发服务器：
    ```bash
@@ -27,6 +27,11 @@
 - dev server 运行在 `http://localhost:5173/admin/`，`/api` 请求会自动代理到后端 8000 端口。
 - 后端关闭时 dev server 进程会一并被清理。
 - 已执行 `npm run build`（存在 `webui/dist`）时，后端直接通过 `/admin` 提供构建产物，不再启动 dev server。
+- 若需要在已有构建产物时强制启动开发服务器，请在项目根目录执行以下命令。标准 Uvicorn 不支持 `--debug` 参数：
+
+  ```bash
+  uvicorn main:app --log-level debug
+  ```
 - 通过环境变量关闭自动启动：`AUTO_START_FRONTEND=0`。
 
 ## 数据库

--- a/main.py
+++ b/main.py
@@ -3,7 +3,9 @@ import logging
 
 from pathlib import Path
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 
 from telegram import Update, Bot
 
@@ -30,6 +32,7 @@ from services import pixiv, storage_service, schema_migrator
 from utils.logging_config import setup_logging
 from utils import frontend_launcher
 from utils.admin_static import AdminStaticFiles, redirect_to_admin
+from utils.api_contract import ErrorBody, ErrorResponse, error_code, error_message
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -53,7 +56,9 @@ async def lifespan(app: FastAPI):
             logger.warning("No storage service set")
         else:
             await storage.get_config()
-        if frontend_launcher.auto_start_enabled() and not dist_dir.exists():
+        if frontend_launcher.should_start_frontend_dev_server(
+            static_build_exists=dist_dir.exists()
+        ):
             await frontend_launcher.start_frontend_dev_server()
         await tg_bot.config()
         await pixiv.read_token_from_config()
@@ -83,6 +88,36 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+
+
+@app.exception_handler(HTTPException)
+async def handle_http_exception(request: Request, exc: HTTPException) -> JSONResponse:
+    del request
+    payload = ErrorResponse(
+        error=ErrorBody(
+            code=error_code(exc.status_code),
+            message=error_message(exc.detail),
+        )
+    )
+    return JSONResponse(status_code=exc.status_code, content=payload.model_dump(exclude_none=True))
+
+
+@app.exception_handler(RequestValidationError)
+async def handle_validation_error(request: Request, exc: RequestValidationError) -> JSONResponse:
+    del request
+    fields: dict[str, list[str]] = {}
+    for item in exc.errors():
+        location = item.get("loc") or ("request",)
+        name = str(location[-1])
+        fields.setdefault(name, []).append(str(item.get("msg", "参数无效")))
+    payload = ErrorResponse(
+        error=ErrorBody(
+            code="validation_error",
+            message="请求参数校验失败",
+            fields=fields,
+        )
+    )
+    return JSONResponse(status_code=422, content=payload.model_dump(exclude_none=True))
 
 for router in (
     dashboard.router,

--- a/registries/command_history_registry.py
+++ b/registries/command_history_registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Sequence
 
-from sqlalchemy import and_, desc, func, select
+from sqlalchemy import and_, asc, desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models import CommandHistory
@@ -58,7 +58,9 @@ async def query_history(
     success: bool | None = None,
     limit: int = 50,
     offset: int = 0,
-) -> tuple[int, list[CommandHistory]]:
+    sort_by: str = "triggered_at",
+    sort_order: str = "desc",
+  ) -> tuple[int, list[CommandHistory]]:
     """Retrieve paginated command history entries applying optional filters."""
 
     async with engine.new_session() as session:
@@ -75,7 +77,9 @@ async def query_history(
         stmt = select(CommandHistory)
         if filters:
             stmt = stmt.where(and_(*filters))
-        stmt = stmt.order_by(desc(CommandHistory.triggered_at)).limit(limit).offset(offset)
+        sort_column = getattr(CommandHistory, sort_by)
+        ordering = desc(sort_column) if sort_order == "desc" else asc(sort_column)
+        stmt = stmt.order_by(ordering, CommandHistory.id).limit(limit).offset(offset)
 
         result = await session.execute(stmt)
         items = result.scalars().all()

--- a/registries/config_registry.py
+++ b/registries/config_registry.py
@@ -301,6 +301,28 @@ async def set_pixiv_token_enabled(token_id: int, enabled: bool) -> None:
         await session.commit()
 
 
+async def set_pixiv_tokens_enabled(token_ids: list[int], enabled: bool) -> None:
+    if not token_ids:
+        return
+
+    async with engine.new_session() as session:
+        result = await session.execute(
+            select(PixivToken).where(PixivToken.id.in_(token_ids))
+        )
+        records = list(result.scalars())
+        found_ids = {record.id for record in records}
+        missing_id = next((token_id for token_id in token_ids if token_id not in found_ids), None)
+        if missing_id is not None:
+            raise ValueError(f"Pixiv token {missing_id} does not exist")
+
+        await session.execute(
+            update(PixivToken)
+            .where(PixivToken.id.in_(token_ids))
+            .values(enabled=enabled)
+        )
+        await session.commit()
+
+
 async def set_all_pixiv_tokens_enabled(enabled: bool) -> None:
     async with engine.new_session() as session:
         await session.execute(

--- a/routers/commands.py
+++ b/routers/commands.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, ConfigDict
 
 from registries.command_history_registry import query_history
+from utils.api_contract import page_meta, page_offset
 
 router = APIRouter(prefix="/api/commands", tags=["commands"])
 
@@ -34,6 +35,9 @@ class CommandHistoryResponse(BaseModel):
 
     total: int
     items: list[CommandHistoryEntry]
+    page: int
+    page_size: int
+    pages: int
 
 
 @router.get("/history", response_model=CommandHistoryResponse)
@@ -41,17 +45,28 @@ async def list_command_history(
     command: str | None = Query(default=None, description="Filter by command name"),
     user_id: int | None = Query(default=None, description="Filter by triggering user"),
     success: bool | None = Query(default=None, description="Filter by execution outcome"),
-    limit: int = Query(default=25, ge=1, le=100),
-    offset: int = Query(default=0, ge=0),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=25, ge=1, le=100),
+    sort_by: str = Query(default="triggered_at"),
+    sort_order: str = Query(default="desc", pattern="^(asc|desc)$"),
 ) -> CommandHistoryResponse:
     """Return paginated command execution history entries."""
+
+    allowed_sort_fields = {
+        "id", "command", "user_id", "chat_id", "success", "duration_ms", "triggered_at"
+    }
+    if sort_by not in allowed_sort_fields:
+        raise HTTPException(status_code=422, detail=f"不支持的排序字段: {sort_by}")
 
     total, items = await query_history(
         command=command,
         user_id=user_id,
         success=success,
-        limit=limit,
-        offset=offset,
+        limit=page_size,
+        offset=page_offset(page, page_size),
+        sort_by=sort_by,
+        sort_order=sort_order,
     )
 
-    return CommandHistoryResponse(total=total, items=items)
+    meta = page_meta(total, page, page_size)
+    return CommandHistoryResponse(items=items, **meta.model_dump())

--- a/routers/groups.py
+++ b/routers/groups.py
@@ -7,11 +7,12 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import String, cast, desc, func, or_, select
+from sqlalchemy import String, asc, cast, desc, func, or_, select
 
 from defines import GroupChatMode, GroupStatus
 from models import Group, GroupChatHistory
 from registries.engine import engine
+from utils.api_contract import page_meta, page_offset
 
 router = APIRouter(prefix="/api/groups", tags=["groups"])
 
@@ -59,6 +60,9 @@ class GroupListResponse(BaseModel):
 
     total: int
     items: list[GroupListItem]
+    page: int
+    page_size: int
+    pages: int
 
 
 class GroupDetail(GroupListItem):
@@ -117,8 +121,10 @@ async def list_groups(
     chat_enabled: bool | None = Query(
         default=None, description="Filter by AI chat enabled flag"
     ),
-    limit: int = Query(default=25, ge=1, le=100),
-    offset: int = Query(default=0, ge=0),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=25, ge=1, le=100),
+    sort_by: str = Query(default="id"),
+    sort_order: str = Query(default="asc", pattern="^(asc|desc)$"),
 ) -> GroupListResponse:
     """List groups with aggregated metadata for the administrative UI."""
 
@@ -134,7 +140,22 @@ async def list_groups(
         )
 
         stmt = _apply_filters(stmt, search=q, enable=enable, chat_enabled=chat_enabled)
-        stmt = stmt.order_by(Group.id).limit(limit).offset(offset)
+        sort_columns = {
+            "id": Group.id,
+            "name": Group.name,
+            "status": Group.status,
+            "enable": Group.enable,
+            "enable_chat": Group.enable_chat,
+            "message_count": func.count(GroupChatHistory.message_id),
+            "last_activity": func.max(GroupChatHistory.sent_at),
+        }
+        if sort_by not in sort_columns:
+            raise HTTPException(status_code=422, detail=f"不支持的排序字段: {sort_by}")
+        sort_column = sort_columns[sort_by]
+        stmt = stmt.order_by(
+            desc(sort_column) if sort_order == "desc" else asc(sort_column),
+            Group.id,
+        ).limit(page_size).offset(page_offset(page, page_size))
         result = await session.execute(stmt)
         rows = result.all()
 
@@ -160,7 +181,8 @@ async def list_groups(
         for row in rows
     ]
 
-    return GroupListResponse(total=total, items=items)
+    meta = page_meta(total, page, page_size)
+    return GroupListResponse(items=items, **meta.model_dump())
 
 
 @router.get("/{group_id}", response_model=GroupDetail)
@@ -220,7 +242,7 @@ async def get_group_detail(group_id: int, recent_limit: int = Query(default=20, 
     )
 
 
-@router.put("/{group_id}", response_model=GroupDetail)
+@router.patch("/{group_id}", response_model=GroupDetail)
 async def update_group(group_id: int, payload: GroupUpdate) -> GroupDetail:
     """Update a group's configuration and return the updated detail object."""
 

--- a/routers/illustrations.py
+++ b/routers/illustrations.py
@@ -10,7 +10,7 @@ import os
 from urllib.parse import urlsplit, urlunsplit
 
 import aiohttp
-from fastapi import APIRouter, File, Form, HTTPException, Response, UploadFile
+from fastapi import APIRouter, File, Form, HTTPException, Query, Response, UploadFile
 from pydantic import BaseModel, Field
 
 from datetime import datetime
@@ -28,6 +28,7 @@ from services.manual_illustration_importer import (
     MAX_IMAGE_BYTES,
     import_manual_illustration,
 )
+from utils.api_contract import page_meta, page_offset
 
 router = APIRouter(prefix="/api/illustrations", tags=["illustrations"])
 
@@ -144,6 +145,9 @@ class IllustrationImportTaskResponse(BaseModel):
 class IllustrationImportTaskListResponse(BaseModel):
     total: int
     items: list[IllustrationImportTaskResponse]
+    page: int
+    page_size: int
+    pages: int
 
 
 def _task_to_response(task: IllustrationImportTask) -> IllustrationImportTaskResponse:
@@ -181,14 +185,27 @@ async def create_import_task_endpoint(
 
 @router.get("/tasks", response_model=IllustrationImportTaskListResponse)
 async def list_import_tasks_endpoint(
-    limit: int = 20,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    status: str | None = Query(default=None, pattern="^(pending|running|success|failed)$"),
+    sort_by: str = Query(default="created_at"),
+    sort_order: str = Query(default="desc", pattern="^(asc|desc)$"),
 ) -> IllustrationImportTaskListResponse:
     """List recent import tasks, newest first."""
-    limit = max(1, min(limit, 100))
-    tasks = await list_import_tasks(limit=limit)
+    allowed_sort_fields = {"id", "pixiv_id", "title", "status", "created_at", "finished_at"}
+    if sort_by not in allowed_sort_fields:
+        raise HTTPException(status_code=422, detail=f"不支持的排序字段: {sort_by}")
+    total, tasks = await list_import_tasks(
+        limit=page_size,
+        offset=page_offset(page, page_size),
+        status=status,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+    meta = page_meta(total, page, page_size)
     return IllustrationImportTaskListResponse(
-        total=len(tasks),
         items=[_task_to_response(task) for task in tasks],
+        **meta.model_dump(),
     )
 
 

--- a/routers/pixiv_tokens.py
+++ b/routers/pixiv_tokens.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from registries import config_registry
@@ -20,6 +20,10 @@ class PixivTokenStatusPayload(BaseModel):
     enabled: bool
 
 
+class PixivTokenBatchStatusPayload(PixivTokenStatusPayload):
+    ids: list[int] | None = None
+
+
 class PixivTokenResponse(BaseModel):
     id: int
     token: str
@@ -30,6 +34,9 @@ class PixivTokenResponse(BaseModel):
 class PixivTokenListResponse(BaseModel):
     total: int
     items: list[PixivTokenResponse]
+    page: int
+    page_size: int
+    pages: int
 
 
 def _mask(token: str | None) -> str:
@@ -50,10 +57,27 @@ def _to_response(record: config_registry.Token) -> PixivTokenResponse:
 
 
 @router.get("", response_model=PixivTokenListResponse)
-async def list_pixiv_tokens() -> PixivTokenListResponse:
+async def list_pixiv_tokens(
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=25, ge=1, le=100),
+    sort_by: str = Query(default="id"),
+    sort_order: str = Query(default="asc", pattern="^(asc|desc)$"),
+) -> PixivTokenListResponse:
     records = await config_registry.get_pixiv_tokens()
     items = [_to_response(record) for record in records if record.id is not None]
-    return PixivTokenListResponse(total=len(items), items=items)
+    if sort_by not in {"id", "enabled"}:
+        raise HTTPException(status_code=422, detail=f"不支持的排序字段: {sort_by}")
+    items.sort(key=lambda item: getattr(item, sort_by), reverse=sort_order == "desc")
+    total = len(items)
+    offset = (page - 1) * page_size
+    pages = (total + page_size - 1) // page_size if total else 0
+    return PixivTokenListResponse(
+        total=total,
+        items=items[offset : offset + page_size],
+        page=page,
+        page_size=page_size,
+        pages=pages,
+    )
 
 
 @router.post("", response_model=PixivTokenResponse)
@@ -81,12 +105,19 @@ async def update_pixiv_token(
     return _to_response(record)
 
 
-@router.patch("/enabled", response_model=PixivTokenListResponse)
+@router.patch("", response_model=PixivTokenListResponse)
 async def set_all_pixiv_tokens_enabled(
-    payload: PixivTokenStatusPayload,
+    payload: PixivTokenBatchStatusPayload,
 ) -> PixivTokenListResponse:
-    await config_registry.set_all_pixiv_tokens_enabled(payload.enabled)
-    return await list_pixiv_tokens()
+    if payload.ids is None:
+        await config_registry.set_all_pixiv_tokens_enabled(payload.enabled)
+    else:
+        for token_id in payload.ids:
+            try:
+                await config_registry.set_pixiv_token_enabled(token_id, payload.enabled)
+            except ValueError as exc:
+                raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return await list_pixiv_tokens(page=1, page_size=25, sort_by="id", sort_order="asc")
 
 
 @router.patch("/{token_id}/status", response_model=PixivTokenResponse)
@@ -111,7 +142,7 @@ async def delete_pixiv_token(token_id: int) -> PixivTokenResponse:
 @router.delete("", response_model=PixivTokenListResponse)
 async def delete_all_pixiv_tokens() -> PixivTokenListResponse:
     await config_registry.delete_all_pixiv_tokens()
-    return PixivTokenListResponse(total=0, items=[])
+    return PixivTokenListResponse(total=0, items=[], page=1, page_size=25, pages=0)
 
 
 @router.post("/reload", response_model=PixivTokenListResponse)
@@ -123,7 +154,7 @@ async def reload_pixiv() -> PixivTokenListResponse:
             await pixiv.token_refresh()
     except Exception:
         raise HTTPException(status_code=500, detail="Failed to reload Pixiv tokens")
-    return await list_pixiv_tokens()
+    return await list_pixiv_tokens(page=1, page_size=25, sort_by="id", sort_order="asc")
 
 
 async def _get_token_or_404(token_id: int) -> config_registry.Token:

--- a/routers/pixiv_tokens.py
+++ b/routers/pixiv_tokens.py
@@ -112,11 +112,10 @@ async def set_all_pixiv_tokens_enabled(
     if payload.ids is None:
         await config_registry.set_all_pixiv_tokens_enabled(payload.enabled)
     else:
-        for token_id in payload.ids:
-            try:
-                await config_registry.set_pixiv_token_enabled(token_id, payload.enabled)
-            except ValueError as exc:
-                raise HTTPException(status_code=404, detail=str(exc)) from exc
+        try:
+            await config_registry.set_pixiv_tokens_enabled(payload.ids, payload.enabled)
+        except ValueError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
     return await list_pixiv_tokens(page=1, page_size=25, sort_by="id", sort_order="asc")
 
 

--- a/routers/private.py
+++ b/routers/private.py
@@ -7,11 +7,12 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import String, cast, desc, func, or_, select
+from sqlalchemy import String, asc, cast, desc, func, or_, select
 
 from defines import MessageType, UserStatus
 from models import PrivateChatHistory, User
 from registries.engine import engine
+from utils.api_contract import page_meta, page_offset
 
 router = APIRouter(prefix="/api/private", tags=["private"])
 
@@ -54,6 +55,9 @@ class PrivateUserListResponse(BaseModel):
 
     total: int
     items: list[PrivateUserListItem]
+    page: int
+    page_size: int
+    pages: int
 
 
 class PrivateUserDetail(PrivateUserListItem):
@@ -102,8 +106,10 @@ async def list_private_users(
     q: str | None = Query(default=None, description="Search by user id or nickname"),
     chat_enabled: bool | None = Query(default=None, description="Filter by chat availability"),
     status: UserStatus | None = Query(default=None, description="Filter by user status"),
-    limit: int = Query(default=25, ge=1, le=100),
-    offset: int = Query(default=0, ge=0),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=25, ge=1, le=100),
+    sort_by: str = Query(default="id"),
+    sort_order: str = Query(default="asc", pattern="^(asc|desc)$"),
 ) -> PrivateUserListResponse:
     """List private users along with message statistics."""
 
@@ -119,7 +125,21 @@ async def list_private_users(
         )
 
         stmt = _apply_filters(stmt, search=q, chat_enabled=chat_enabled, status=status)
-        stmt = stmt.order_by(User.id).limit(limit).offset(offset)
+        sort_columns = {
+            "id": User.id,
+            "nick_name": User.nick_name,
+            "status": User.status,
+            "enable_chat": User.enable_chat,
+            "message_count": func.count(PrivateChatHistory.message_id),
+            "last_activity": func.max(PrivateChatHistory.sent_at),
+        }
+        if sort_by not in sort_columns:
+            raise HTTPException(status_code=422, detail=f"不支持的排序字段: {sort_by}")
+        sort_column = sort_columns[sort_by]
+        stmt = stmt.order_by(
+            desc(sort_column) if sort_order == "desc" else asc(sort_column),
+            User.id,
+        ).limit(page_size).offset(page_offset(page, page_size))
         result = await session.execute(stmt)
         rows = result.all()
 
@@ -141,7 +161,8 @@ async def list_private_users(
         for row in rows
     ]
 
-    return PrivateUserListResponse(total=total, items=items)
+    meta = page_meta(total, page, page_size)
+    return PrivateUserListResponse(items=items, **meta.model_dump())
 
 
 @router.get("/users/{user_id}", response_model=PrivateUserDetail)
@@ -198,7 +219,7 @@ async def get_private_user(
     )
 
 
-@router.put("/users/{user_id}", response_model=PrivateUserDetail)
+@router.patch("/users/{user_id}", response_model=PrivateUserDetail)
 async def update_private_user(user_id: int, payload: PrivateUserUpdate) -> PrivateUserDetail:
     """Update private user preferences and return the updated detail."""
 

--- a/services/illustration_import_runner.py
+++ b/services/illustration_import_runner.py
@@ -11,7 +11,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import asc, desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models import IllustrationImportTask
@@ -140,15 +140,30 @@ async def _run_import_task(task_id: int) -> None:
         )
 
 
-async def list_import_tasks(limit: int = 20) -> list[IllustrationImportTask]:
+async def list_import_tasks(
+    *,
+    limit: int = 20,
+    offset: int = 0,
+    status: str | None = None,
+    sort_by: str = "created_at",
+    sort_order: str = "desc",
+) -> tuple[int, list[IllustrationImportTask]]:
     async with engine.new_session() as session:
         session: AsyncSession = session
+        sort_column = getattr(IllustrationImportTask, sort_by)
+        stmt = select(IllustrationImportTask)
+        count_stmt = select(func.count()).select_from(IllustrationImportTask)
+        if status is not None:
+            stmt = stmt.where(IllustrationImportTask.status == status)
+            count_stmt = count_stmt.where(IllustrationImportTask.status == status)
+        ordering = desc(sort_column) if sort_order == "desc" else asc(sort_column)
         result = await session.execute(
-            select(IllustrationImportTask)
-            .order_by(IllustrationImportTask.id.desc())
+            stmt.order_by(ordering, IllustrationImportTask.id.desc())
             .limit(limit)
+            .offset(offset)
         )
-        return list(result.scalars())
+        total = (await session.execute(count_stmt)).scalar_one()
+        return total, list(result.scalars())
 
 
 async def get_import_task(task_id: int) -> IllustrationImportTask | None:

--- a/tests/e2e/test_live_api.py
+++ b/tests/e2e/test_live_api.py
@@ -18,9 +18,17 @@ ONE_PIXEL_PNG = base64.b64decode(
 
 
 def test_health(live_server_url, http_client):
-    response = http_client.get("/")
-    assert response.status_code == 200
-    assert response.json() == {"message": "Hello World"}
+    response = http_client.get("/", follow_redirects=False)
+    if (PROJECT_ROOT / "webui" / "dist").exists():
+        assert response.status_code == 307
+        assert response.headers["location"] == "/admin/"
+
+        admin_response = http_client.get("/admin/")
+        assert admin_response.status_code == 200
+        assert "text/html" in admin_response.headers["content-type"]
+    else:
+        assert response.status_code == 200
+        assert response.json() == {"message": "Hello World"}
 
 
 def test_feature_flags(live_server_url, http_client):
@@ -69,8 +77,9 @@ def test_pixiv_tokens_flow(live_server_url, http_client):
     data = http_client.get("/api/pixiv-tokens").json()
     assert data["total"] >= 2
 
-    response = http_client.patch("/api/pixiv-tokens/enabled", json={"enabled": False})
+    response = http_client.patch("/api/pixiv-tokens", json={"enabled": False})
     assert response.status_code == 200
+    assert all(item["enabled"] is False for item in response.json()["items"])
 
     response = http_client.delete("/api/pixiv-tokens")
     assert response.status_code == 200

--- a/tests/system/test_api_illustrations.py
+++ b/tests/system/test_api_illustrations.py
@@ -137,7 +137,12 @@ def test_manual_import_maps_mocked_validation_error(client, monkeypatch):
     )
 
     assert response.status_code == 400
-    assert response.json() == {"detail": "仅支持 JPG、PNG、GIF 和 WebP 图片"}
+    assert response.json() == {
+        "error": {
+            "code": "bad_request",
+            "message": "仅支持 JPG、PNG、GIF 和 WebP 图片",
+        }
+    }
 
 
 def test_manual_import_bounds_upload_read(client, monkeypatch):
@@ -159,7 +164,9 @@ def test_manual_import_bounds_upload_read(client, monkeypatch):
     )
 
     assert response.status_code == 400
-    assert response.json() == {"detail": "图片不能超过 20 MB"}
+    assert response.json() == {
+        "error": {"code": "bad_request", "message": "图片不能超过 20 MB"}
+    }
 
 
 def test_task_list_and_missing_task(client, pixiv_enabled, monkeypatch):

--- a/tests/system/test_api_pagination.py
+++ b/tests/system/test_api_pagination.py
@@ -1,0 +1,37 @@
+"""Tests for the admin API pagination contract."""
+
+
+def test_group_list_uses_page_contract(client):
+    response = client.get(
+        "/api/groups",
+        params={"page": 1, "page_size": 10, "sort_by": "id", "sort_order": "desc"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [],
+        "total": 0,
+        "page": 1,
+        "page_size": 10,
+        "pages": 0,
+    }
+
+
+def test_command_history_rejects_unknown_sort_field(client):
+    response = client.get("/api/commands/history", params={"sort_by": "not_a_field"})
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"
+
+
+def test_import_tasks_exposes_page_contract(client):
+    response = client.get("/api/illustrations/tasks", params={"page": 1, "page_size": 10})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [],
+        "total": 0,
+        "page": 1,
+        "page_size": 10,
+        "pages": 0,
+    }

--- a/tests/system/test_api_pixiv_tokens.py
+++ b/tests/system/test_api_pixiv_tokens.py
@@ -40,6 +40,20 @@ def test_toggle_all_tokens(client):
     assert all(item["enabled"] is False for item in response.json()["items"])
 
 
+def test_selective_toggle_validates_all_ids_before_writing(client):
+    client.post("/api/pixiv-tokens", json={"token": TOKEN_A, "enabled": True})
+    client.post("/api/pixiv-tokens", json={"token": TOKEN_B, "enabled": True})
+
+    response = client.patch(
+        "/api/pixiv-tokens",
+        json={"ids": [1, 999], "enabled": False},
+    )
+
+    assert response.status_code == 404
+    items = client.get("/api/pixiv-tokens").json()["items"]
+    assert all(item["enabled"] is True for item in items)
+
+
 def test_update_token(client):
     client.post("/api/pixiv-tokens", json={"token": TOKEN_A})
     response = client.put("/api/pixiv-tokens/1", json={"token": "REFRESH_TOKEN_UPDATED"})

--- a/tests/system/test_api_pixiv_tokens.py
+++ b/tests/system/test_api_pixiv_tokens.py
@@ -12,7 +12,7 @@ def test_initial_list_is_empty(client):
 
 def test_add_multiple_tokens(client):
     response = client.post("/api/pixiv-tokens", json={"token": TOKEN_A, "enabled": True})
-    assert response.status_code == 200
+    assert response.status_code == 200, response.text
     first = response.json()
     assert first["id"] == 1
     assert first["masked"] == "REFR...AAAA"
@@ -35,8 +35,8 @@ def test_toggle_single_token(client):
 def test_toggle_all_tokens(client):
     client.post("/api/pixiv-tokens", json={"token": TOKEN_A})
     client.post("/api/pixiv-tokens", json={"token": TOKEN_B})
-    response = client.patch("/api/pixiv-tokens/enabled", json={"enabled": False})
-    assert response.status_code == 200
+    response = client.patch("/api/pixiv-tokens", json={"enabled": False})
+    assert response.status_code == 200, response.text
     assert all(item["enabled"] is False for item in response.json()["items"])
 
 

--- a/tests/unit/test_frontend_launcher.py
+++ b/tests/unit/test_frontend_launcher.py
@@ -1,0 +1,28 @@
+"""Regression tests for the frontend auto-start decision."""
+
+from utils import frontend_launcher
+
+
+def test_debug_log_level_starts_dev_server_when_a_static_build_exists(monkeypatch):
+    """An explicit Uvicorn debug log level selects Vite over the static build."""
+    monkeypatch.delenv("AUTO_START_FRONTEND", raising=False)
+
+    should_start = getattr(frontend_launcher, "should_start_frontend_dev_server", None)
+
+    assert should_start is not None
+    assert should_start(
+        static_build_exists=True,
+        argv=["uvicorn", "main:app", "--log-level", "debug"],
+    )
+
+
+def test_explicit_disable_overrides_debug_log_level(monkeypatch):
+    monkeypatch.setenv("AUTO_START_FRONTEND", "0")
+
+    should_start = getattr(frontend_launcher, "should_start_frontend_dev_server", None)
+
+    assert should_start is not None
+    assert not should_start(
+        static_build_exists=True,
+        argv=["uvicorn", "main:app", "--log-level=debug"],
+    )

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,0 +1,47 @@
+import json
+import logging
+from datetime import datetime
+
+from utils.logging_config import JsonFormatter, setup_logging
+
+
+def test_json_log_format_serializes_core_record_fields() -> None:
+    record = logging.LogRecord(
+        name="test.logger",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=42,
+        msg="Something happened: %s",
+        args=("now",),
+        exc_info=None,
+    )
+
+    formatter = JsonFormatter(datefmt="%Y-%m-%d")
+    payload = json.loads(formatter.format(record))
+
+    assert payload == {
+        "timestamp": datetime.fromtimestamp(record.created).strftime("%Y-%m-%d"),
+        "level": "WARNING",
+        "logger": "test.logger",
+        "line": 42,
+        "message": "Something happened: now",
+    }
+
+
+def test_setup_logging_treats_json_as_a_formatter_mode(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def capture_config(config: dict[str, object]) -> None:
+        captured.update(config)
+
+    monkeypatch.setenv("LOG_FORMAT", "json")
+    monkeypatch.setattr("logging.config.dictConfig", capture_config)
+
+    setup_logging(force=True)
+
+    formatters = captured["formatters"]
+    assert isinstance(formatters, dict)
+    assert formatters["detailed"] == {
+        "()": "utils.logging_config.JsonFormatter",
+        "datefmt": "%Y-%m-%d %H:%M:%S",
+    }

--- a/utils/api_contract.py
+++ b/utils/api_contract.py
@@ -1,0 +1,57 @@
+"""Shared response and pagination contracts for the admin API."""
+
+from __future__ import annotations
+
+from math import ceil
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class ErrorBody(BaseModel):
+    code: str
+    message: str
+    fields: dict[str, list[str]] | None = None
+
+
+class ErrorResponse(BaseModel):
+    error: ErrorBody
+
+
+class PageMeta(BaseModel):
+    total: int
+    page: int
+    page_size: int
+    pages: int
+
+
+def page_meta(total: int, page: int, page_size: int) -> PageMeta:
+    return PageMeta(
+        total=total,
+        page=page,
+        page_size=page_size,
+        pages=ceil(total / page_size) if total else 0,
+    )
+
+
+def page_offset(page: int, page_size: int) -> int:
+    return (page - 1) * page_size
+
+
+def error_code(status_code: int) -> str:
+    return {
+        400: "bad_request",
+        404: "not_found",
+        409: "conflict",
+        422: "validation_error",
+        502: "upstream_error",
+        503: "service_unavailable",
+    }.get(status_code, "internal_error")
+
+
+def error_message(detail: Any) -> str:
+    if isinstance(detail, str):
+        return detail
+    if isinstance(detail, list):
+        return "请求参数校验失败"
+    return "请求处理失败"

--- a/utils/frontend_launcher.py
+++ b/utils/frontend_launcher.py
@@ -7,7 +7,9 @@ import asyncio
 import logging
 import os
 import re
+import subprocess
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -24,7 +26,7 @@ for _stream in (sys.stdout, sys.stderr):
 _ANSI_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 #: Handle to the spawned Vite dev server process, if any.
-_dev_server: asyncio.subprocess.Process | None = None
+_dev_server: asyncio.subprocess.Process | subprocess.Popen[bytes] | None = None
 
 WEBUI_DIR = Path(__file__).resolve().parent.parent / "webui"
 DEFAULT_PORT = 5173
@@ -33,6 +35,32 @@ DEFAULT_PORT = 5173
 def auto_start_enabled() -> bool:
     value = (os.getenv("AUTO_START_FRONTEND") or "1").strip().lower()
     return value not in {"0", "false", "no", "off"}
+
+
+def should_start_frontend_dev_server(
+    *,
+    static_build_exists: bool,
+    argv: Sequence[str] | None = None,
+) -> bool:
+    """Decide whether this process should launch the Vite development server.
+
+    A Uvicorn ``--log-level debug`` invocation explicitly selects the dev WebUI,
+    even when a static production build is available.  An explicit
+    ``AUTO_START_FRONTEND=0`` remains an opt-out for all modes.
+    """
+    if not auto_start_enabled():
+        return False
+    if not static_build_exists:
+        return True
+
+    arguments = list(sys.argv if argv is None else argv)
+    for index, argument in enumerate(arguments):
+        normalized = argument.lower()
+        if normalized == "--log-level=debug":
+            return True
+        if normalized == "--log-level" and index + 1 < len(arguments):
+            return arguments[index + 1].lower() == "debug"
+    return False
 
 
 def _build_command() -> list[str]:
@@ -52,7 +80,11 @@ async def start_frontend_dev_server() -> bool:
     """
     global _dev_server
 
-    if _dev_server is not None and _dev_server.returncode is None:
+    if _dev_server is not None and (
+        _dev_server.returncode is None
+        if isinstance(_dev_server, asyncio.subprocess.Process)
+        else _dev_server.poll() is None
+    ):
         return True
 
     if not WEBUI_DIR.is_dir():
@@ -61,12 +93,25 @@ async def start_frontend_dev_server() -> bool:
 
     command = _build_command()
     try:
-        proc = await asyncio.create_subprocess_exec(
-            *command,
-            cwd=str(WEBUI_DIR),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-        )
+        if sys.platform == "win32":
+            # SelectorEventLoop (the default in some Windows hosts, including
+            # Python 3.14 integrations) does not implement subprocess_exec.
+            # Popen in a worker thread keeps startup independent of the loop
+            # policy while preserving async lifecycle management below.
+            proc = await asyncio.to_thread(
+                subprocess.Popen,
+                command,
+                cwd=str(WEBUI_DIR),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+        else:
+            proc = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=str(WEBUI_DIR),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
     except FileNotFoundError:
         logger.warning(
             "npm not found; cannot auto-start the frontend dev server "
@@ -88,12 +133,15 @@ async def start_frontend_dev_server() -> bool:
     return True
 
 
-async def _pump_output(proc: asyncio.subprocess.Process) -> None:
+async def _pump_output(proc: asyncio.subprocess.Process | subprocess.Popen[bytes]) -> None:
     """Forward the dev server's output into the backend log."""
     assert proc.stdout is not None
     try:
         while True:
-            line = await proc.stdout.readline()
+            if isinstance(proc, subprocess.Popen):
+                line = await asyncio.to_thread(proc.stdout.readline)
+            else:
+                line = await proc.stdout.readline()
             if not line:
                 break
             logger.info("frontend: %s", _ANSI_RE.sub("", line.decode(errors="replace")).strip())
@@ -101,10 +149,13 @@ async def _pump_output(proc: asyncio.subprocess.Process) -> None:
         pass
 
 
-async def _watch_startup(proc: asyncio.subprocess.Process) -> None:
+async def _watch_startup(proc: asyncio.subprocess.Process | subprocess.Popen[bytes]) -> None:
     """Detect an early exit of the dev server (e.g. npm error) and log it."""
     try:
-        await asyncio.wait_for(proc.wait(), timeout=5)
+        if isinstance(proc, subprocess.Popen):
+            await asyncio.wait_for(asyncio.to_thread(proc.wait), timeout=5)
+        else:
+            await asyncio.wait_for(proc.wait(), timeout=5)
     except asyncio.TimeoutError:
         return  # still running after 5s — assume healthy
     if proc.returncode != 0:
@@ -131,12 +182,13 @@ async def stop_frontend_dev_server() -> None:
     logger.info("Stopping frontend dev server (pid=%s)", proc.pid)
     if sys.platform == "win32":
         try:
-            killer = await asyncio.create_subprocess_exec(
-                "taskkill", "/PID", str(proc.pid), "/T", "/F",
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
+            await asyncio.to_thread(
+                subprocess.run,
+                ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
             )
-            await killer.wait()
         except Exception:
             logger.exception("taskkill failed; falling back to terminate()")
             proc.terminate()
@@ -144,6 +196,9 @@ async def stop_frontend_dev_server() -> None:
         proc.terminate()
 
     try:
-        await asyncio.wait_for(proc.wait(), timeout=5)
+        if isinstance(proc, subprocess.Popen):
+            await asyncio.wait_for(asyncio.to_thread(proc.wait), timeout=5)
+        else:
+            await asyncio.wait_for(proc.wait(), timeout=5)
     except asyncio.TimeoutError:
         proc.kill()

--- a/utils/logging_config.py
+++ b/utils/logging_config.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import logging.config
 import os
@@ -7,6 +8,22 @@ from typing import Any
 
 _DEFAULT_FORMAT = "%(asctime)s | %(levelname)-8s | %(name)s:%(lineno)d | %(message)s"
 _DEFAULT_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+class JsonFormatter(logging.Formatter):
+    """Serialize log records for environments configured with LOG_FORMAT=json."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "line": record.lineno,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        return json.dumps(payload, ensure_ascii=False)
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -37,6 +54,18 @@ def setup_logging(force: bool = False) -> None:
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
     log_format = os.getenv("LOG_FORMAT", _DEFAULT_FORMAT)
     date_format = os.getenv("LOG_DATE_FORMAT", _DEFAULT_DATE_FORMAT)
+
+    formatter: dict[str, Any]
+    if log_format.strip().lower() == "json":
+        formatter = {
+            "()": "utils.logging_config.JsonFormatter",
+            "datefmt": date_format,
+        }
+    else:
+        formatter = {
+            "format": log_format,
+            "datefmt": date_format,
+        }
 
     log_to_file = _env_bool("LOG_TO_FILE", False)
     log_file = os.getenv("LOG_FILE", "logs/app.log")
@@ -70,10 +99,7 @@ def setup_logging(force: bool = False) -> None:
         "version": 1,
         "disable_existing_loggers": False,
         "formatters": {
-            "detailed": {
-                "format": log_format,
-                "datefmt": date_format,
-            }
+            "detailed": formatter
         },
         "handlers": handlers,
         "root": {
@@ -108,4 +134,4 @@ def setup_logging(force: bool = False) -> None:
     logging.captureWarnings(True)
 
 
-__all__ = ["setup_logging"]
+__all__ = ["JsonFormatter", "setup_logging"]

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -8,19 +8,19 @@
       "name": "acgimg-admin-console",
       "version": "0.1.0",
       "dependencies": {
-        "@primeuix/themes": "^3.0.0",
+        "@mdi/font": "^7.4.47",
         "axios": "^1.19.0",
-        "primeflex": "^4.0.0",
-        "primeicons": "^8.0.0",
-        "primevue": "^5.0.0",
         "vue": "^3.4.15",
-        "vue-router": "^5.2.0"
+        "vue-router": "^5.2.0",
+        "vuetify": "^4.1.11"
       },
       "devDependencies": {
-        "@types/node": "^26.1.2",
+        "@types/node": "^26.2.0",
         "@vitejs/plugin-vue": "^6.0.8",
-        "typescript": "^7.0.2",
-        "vite": "^8.2.1"
+        "typescript": "^6.0.3",
+        "vite": "^8.2.2",
+        "vite-plugin-vuetify": "^2.1.2",
+        "vue-tsc": "^3.0.6"
       }
     },
     "node_modules/@babel/generator": {
@@ -177,155 +177,42 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@noble/ed25519": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
-      "integrity": "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
+    "node_modules/@mdi/font": {
+      "version": "7.4.47",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.4.47.tgz",
+      "integrity": "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
-      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
       "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
     },
-    "node_modules/@primeicons/core": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@primeicons/core/-/core-8.0.0.tgz",
-      "integrity": "sha512-vPif+sXxajXCSL2bmNBP0QYliJONVRgFVpCg9e7hGn7IG18JkMAm4fF5HVld1N4sDATkZQM7jKVxdZ8EK09Giw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeuix/utils": "^0.8.0"
-      }
-    },
-    "node_modules/@primeicons/vue": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@primeicons/vue/-/vue-8.0.0.tgz",
-      "integrity": "sha512-sIqk+kZB9Bn0FqODjDAnNvRXY4Ypky2TInY/oIC3aAJOud1A3FoKruMC8IwiRDz1uHzxYnQqWwtFsfZAgC7qXQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeicons/core": "8.0.0",
-        "@primeuix/utils": "^0.8.0"
-      },
-      "peerDependencies": {
-        "vue": "^3"
-      }
-    },
-    "node_modules/@primeui/license-manager": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@primeui/license-manager/-/license-manager-1.0.0.tgz",
-      "integrity": "sha512-89J7r8cclEqoHVwjOX1adPcB/blFSocpzuYlzmd+6r0gxzg2Vd4jM54TKXt9/qwAT/kOv4vYnHKZ6hcP2GFtfA==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@noble/ed25519": "2.3.0",
-        "@noble/hashes": "2.2.0"
-      }
-    },
-    "node_modules/@primeuix/motion": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/motion/-/motion-1.0.0.tgz",
-      "integrity": "sha512-rqpFRKmUVp9BI3YQKdok0rLUwzYShXzuuxy72Kq74xYRV14eR+4+XrIXOdyVs7j7CYV0ajYowiRpJCrVgdrq6A==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeuix/utils": "^0.8.0"
-      },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
       "engines": {
-        "node": ">=12.11.0"
-      }
-    },
-    "node_modules/@primeuix/styled": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-1.0.0.tgz",
-      "integrity": "sha512-6SXoeQWwKswSqTv1ygaXNfY7otHo6Rb9mxbKJK5WF8adWlZ6CtwmlNfIP+p8cH/zGccsei/5Bu7IetXlMoZGjQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeui/license-manager": "^1.0.0",
-        "@primeuix/utils": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=12.11.0"
-      }
-    },
-    "node_modules/@primeuix/styles": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/styles/-/styles-3.0.0.tgz",
-      "integrity": "sha512-nFsG2V0kbn3Q/fr0EV0Lxy2cKeW1F+WFXyxWI1CxWAAXW34mTCLkDd6OFbN5dP9hrSJOVaeXWzTdoonh1sdklQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeuix/styled": "^1.0.0"
-      }
-    },
-    "node_modules/@primeuix/themes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/themes/-/themes-3.0.0.tgz",
-      "integrity": "sha512-lNMOhorzu4vHRKbTDIU2/raS7/Z6Oyq2WXGfFDVhOwAIVDF4e7hCX75jlgfC7bo4D0Bl5f+oW5HPGZpG52r6lw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeuix/styled": "^1.0.0"
-      }
-    },
-    "node_modules/@primeuix/utils": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.8.0.tgz",
-      "integrity": "sha512-dZSMKU2XJ7W7VDLuFMS/o4k+QYw4SYIpqSNhR/jdasMaaXl8eq0Gt7fTzTwwq7hgfmfOsI6V5xtzUUIvybOJ/w==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "engines": {
-        "node": ">=12.11.0"
-      }
-    },
-    "node_modules/@primevue/core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@primevue/core/-/core-5.0.0.tgz",
-      "integrity": "sha512-VGw1a5m3bSHosAQScg7huvD8ZFQ4cfltmbIuOSx7gsMS2NnYno9BCIq7O2L2H3zmB0pBLfcpdawb3EPeg1LIxw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeui/license-manager": "^1.0.0",
-        "@primeuix/styled": "^1.0.0",
-        "@primeuix/utils": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=12.11.0"
-      },
-      "peerDependencies": {
-        "vue": "^3.5.0"
-      }
-    },
-    "node_modules/@primevue/icons": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@primevue/icons/-/icons-5.0.0.tgz",
-      "integrity": "sha512-DyrtQhmLRiIkldjm5jmuqiFeNN05n4VWd1sw4+WfJ0Zlb+5T4YASw6CGtCITPzHVYyx6XuuEMifruzc8OVpQrw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeuix/utils": "^0.8.0",
-        "@primevue/core": "5.0.0"
-      },
-      "engines": {
-        "node": ">=12.11.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
-      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
       "cpu": [
         "arm64"
       ],
@@ -339,9 +226,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
-      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
       "cpu": [
         "arm64"
       ],
@@ -355,9 +242,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
-      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
       "cpu": [
         "x64"
       ],
@@ -371,9 +258,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
-      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
       "cpu": [
         "x64"
       ],
@@ -387,9 +274,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
-      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
       "cpu": [
         "arm"
       ],
@@ -403,9 +290,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
-      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
       "cpu": [
         "arm64"
       ],
@@ -419,9 +306,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
-      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
       "cpu": [
         "arm64"
       ],
@@ -435,9 +322,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
-      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
       "cpu": [
         "ppc64"
       ],
@@ -451,9 +338,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
-      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
       "cpu": [
         "s390x"
       ],
@@ -467,9 +354,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
-      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
       "cpu": [
         "x64"
       ],
@@ -483,9 +370,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
-      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
       "cpu": [
         "x64"
       ],
@@ -499,9 +386,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
-      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
       "cpu": [
         "arm64"
       ],
@@ -515,9 +402,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
-      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
       "cpu": [
         "arm64"
       ],
@@ -531,9 +418,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
-      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
       "cpu": [
         "x64"
       ],
@@ -560,333 +447,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
-      }
-    },
-    "node_modules/@typescript/typescript-aix-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
-      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-darwin-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
-      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-darwin-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
-      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-freebsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-freebsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
-      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-arm": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
-      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
-      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-loong64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
-      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-mips64el": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
-      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
-      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-riscv64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
-      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-s390x": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
-      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
-      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-sunos-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
-      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
-      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
-      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -904,6 +471,35 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
       }
     },
     "node_modules/@vue-macros/common": {
@@ -1010,6 +606,22 @@
       "integrity": "sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==",
       "license": "MIT"
     },
+    "node_modules/@vue/language-core": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.11.tgz",
+      "integrity": "sha512-QJmpliwAVpC/OxubIByPAhNzsQPRc8/gxlN2qnVzVfIMjMDz/9RnXRFoetjz5yEgXVXyp4LqhXq3V53PjmNzFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.2.1",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
+      }
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.5.41",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.41.tgz",
@@ -1058,6 +670,20 @@
       "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
       "license": "MIT"
     },
+    "node_modules/@vuetify/loader-shared": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@vuetify/loader-shared/-/loader-shared-2.1.2.tgz",
+      "integrity": "sha512-X+1jBLmXHkpQEnC0vyOb4rtX2QSkBiFhaFXz8yhQqN2A4vQ6k2nChxN4Ol7VAY5KoqMdFoRMnmNdp/1qYXDQig==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "upath": "^2.0.1"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0",
+        "vuetify": ">=3"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -1081,6 +707,13 @@
       "engines": {
         "node": ">= 6.0.0"
       }
+    },
+    "node_modules/alien-signals": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ast-kit": {
       "version": "2.2.0",
@@ -1883,9 +1516,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -1904,6 +1537,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/nostics/-/nostics-1.2.0.tgz",
       "integrity": "sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==",
+      "license": "MIT"
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -1948,9 +1588,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1967,43 +1607,12 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/primeflex": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/primeflex/-/primeflex-4.0.0.tgz",
-      "integrity": "sha512-UOEZCRjR36+sm5bUpDhS1xbA068l9VC6y1aTNVqQPtXuKIdPTqAWHRUxj3mKAoPrQ9W373ooJJMgNVXfiaw04g==",
-      "license": "MIT"
-    },
-    "node_modules/primeicons": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/primeicons/-/primeicons-8.0.0.tgz",
-      "integrity": "sha512-eZGk+Mgb4fE+LkJi9LvllbnB4RVUF9kzmnLVnT3ZMY6stqKVh7TUJ0mFoMNIEgTnJSvhaGcJotDiSvtVvkHd7g==",
-      "license": "SEE LICENSE IN LICENSE.md"
-    },
-    "node_modules/primevue": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/primevue/-/primevue-5.0.0.tgz",
-      "integrity": "sha512-o0MtP6Dxa5QFZuskBWoiLD7aM/V6emqqJJnd+L2nNSfH4PrQsNpqSVPZODSdNJfKXAD9ekjTAJ+QyHycKCmF3Q==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@primeicons/vue": "^8.0.0",
-        "@primeui/license-manager": "^1.0.0",
-        "@primeuix/motion": "^1.0.0",
-        "@primeuix/styled": "^1.0.0",
-        "@primeuix/styles": "^3.0.0",
-        "@primeuix/utils": "^0.8.0",
-        "@primevue/core": "5.0.0",
-        "@primevue/icons": "5.0.0"
-      },
-      "engines": {
-        "node": ">=12.11.0"
       }
     },
     "node_modules/proxy-from-env": {
@@ -2045,13 +1654,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
-      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.143.0",
+        "@oxc-project/types": "=0.146.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -2061,20 +1670,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.2.3",
-        "@rolldown/binding-darwin-arm64": "1.2.3",
-        "@rolldown/binding-darwin-x64": "1.2.3",
-        "@rolldown/binding-freebsd-x64": "1.2.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
-        "@rolldown/binding-linux-arm64-musl": "1.2.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
-        "@rolldown/binding-linux-x64-gnu": "1.2.3",
-        "@rolldown/binding-linux-x64-musl": "1.2.3",
-        "@rolldown/binding-openharmony-arm64": "1.2.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
-        "@rolldown/binding-win32-x64-msvc": "1.2.3"
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
       }
     },
     "node_modules/scule": {
@@ -2109,38 +1719,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc"
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=16.20.0"
-      },
-      "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
+        "node": ">=14.17"
       }
     },
     "node_modules/ufo": {
@@ -2226,17 +1815,28 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
+    "node_modules/upath": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
+      "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      }
+    },
     "node_modules/vite": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
-      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.25",
-        "rolldown": "~1.2.1",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -2253,7 +1853,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.4.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -2303,6 +1903,33 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-plugin-vuetify": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-vuetify/-/vite-plugin-vuetify-2.1.3.tgz",
+      "integrity": "sha512-Q4SC/4TqbNvaZIFb9YsfBqkGlYHbJJJ6uU3CnRBZqLUF3s5eCMVZAaV4GkTbehIH/bhSj42lMXztOwc71u6rVw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vuetify/loader-shared": "^2.1.2",
+        "debug": "^4.3.3",
+        "upath": "^2.0.1"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">=5",
+        "vue": "^3.0.0",
+        "vuetify": ">=3"
+      }
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue": {
       "version": "3.5.41",
@@ -2371,6 +1998,50 @@
           "optional": true
         },
         "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.11.tgz",
+      "integrity": "sha512-gOb0B9rtU2+f1dszwPqSH5kAieIF9ReeLhD3kSRNHv5WZZUQz/JdVXW0RTdqhNTMlQkqKzrTTviqKr/4FYZraQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.3.11"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/vuetify": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.11.tgz",
+      "integrity": "sha512-pMzGsjha58Lbg9n/icMXCxcQN9rTczcOdMq3wMU1Qe+cfufl28eX4VUUzLwSsDgmLjTtUGsgZIkyYZFQy+SmIw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/johnleider"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7",
+        "vite-plugin-vuetify": ">=2.1.0",
+        "vue": "^3.5.0 || ^3.6.0-0",
+        "webpack-plugin-vuetify": ">=3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vite-plugin-vuetify": {
+          "optional": true
+        },
+        "webpack-plugin-vuetify": {
           "optional": true
         }
       }

--- a/webui/package.json
+++ b/webui/package.json
@@ -6,21 +6,24 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "vue-tsc --noEmit --skipLibCheck",
+    "test": "node --test --experimental-strip-types tests/*.test.ts",
+    "test:typecheck": "vue-tsc --noEmit --skipLibCheck -p tsconfig.tests.json"
   },
   "dependencies": {
-    "@primeuix/themes": "^3.0.0",
+    "@mdi/font": "^7.4.47",
     "axios": "^1.19.0",
-    "primeflex": "^4.0.0",
-    "primeicons": "^8.0.0",
-    "primevue": "^5.0.0",
     "vue": "^3.4.15",
-    "vue-router": "^5.2.0"
+    "vue-router": "^5.2.0",
+    "vuetify": "^4.1.11"
   },
   "devDependencies": {
-    "@types/node": "^26.1.2",
+    "@types/node": "^26.2.0",
     "@vitejs/plugin-vue": "^6.0.8",
-    "typescript": "^7.0.2",
-    "vite": "^8.2.1"
+    "typescript": "^6.0.3",
+    "vite": "^8.2.2",
+    "vite-plugin-vuetify": "^2.1.2",
+    "vue-tsc": "^3.0.6"
   }
 }

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -1,46 +1,89 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-import { useRoute, useRouter, RouterView } from 'vue-router';
+import { computed, ref } from 'vue';
+import { useRoute, RouterView } from 'vue-router';
+import { useDisplay, useTheme } from 'vuetify';
 
 import AppHeader from '@/components/AppHeader.vue';
 import AppSidebar from '@/components/AppSidebar.vue';
+import {
+  acceptConfirmation,
+  confirmState,
+  feedbackState,
+  rejectConfirmation
+} from '@/composables/feedback';
 
-const router = useRouter();
 const route = useRoute();
-
+const theme = useTheme();
+const { mdAndUp } = useDisplay();
+const drawer = ref<boolean | null>(null);
 const navItems = [
-  { label: '仪表盘', icon: 'pi pi-chart-line', to: '/dashboard' },
-  { label: '群组管理', icon: 'pi pi-users', to: '/groups' },
-  { label: '私聊管理', icon: 'pi pi-comments', to: '/private' },
-  { label: '命令历史', icon: 'pi pi-list', to: '/commands' },
-  { label: '功能配置', icon: 'pi pi-sliders-h', to: '/features' },
-  { label: 'Bot Token', icon: 'pi pi-key', to: '/bot-tokens' },
-  { label: 'Pixiv Token', icon: 'pi pi-palette', to: '/pixiv-tokens' },
-  { label: '插画导入', icon: 'pi pi-upload', to: '/illustrations/import' }
+  { label: '仪表盘', icon: 'mdi-view-dashboard-outline', to: '/dashboard' },
+  { label: '群组管理', icon: 'mdi-account-group-outline', to: '/groups' },
+  { label: '私聊管理', icon: 'mdi-message-processing-outline', to: '/private' },
+  { label: '命令历史', icon: 'mdi-history', to: '/commands' },
+  { label: '功能配置', icon: 'mdi-tune-variant', to: '/features' },
+  { label: 'Bot Token', icon: 'mdi-key-outline', to: '/bot-tokens' },
+  { label: 'Pixiv Token', icon: 'mdi-palette-outline', to: '/pixiv-tokens' },
+  { label: '插画导入', icon: 'mdi-image-plus-outline', to: '/illustrations/import' }
 ];
-
 const activePath = computed(() => route.path);
-
-function handleNavigate(path: string) {
-  if (path !== route.path) {
-    router.push(path);
+const dark = computed(() => theme.global.current.value.dark);
+const confirmationDialog = computed({
+  get: () => confirmState.open,
+  set: (value: boolean) => {
+    if (!value) rejectConfirmation();
   }
+});
+
+function closeDrawer() {
+  if (!mdAndUp.value) drawer.value = false;
+}
+
+function toggleTheme() {
+  const next = dark.value ? 'light' : 'dark';
+  theme.global.name.value = next;
+  localStorage.setItem('acgimg-theme', next);
 }
 </script>
 
 <template>
-  <div class="layout-shell">
-    <AppHeader :items="navItems" :active-path="activePath" @navigate="handleNavigate" />
-    <div class="layout-content">
-      <AppSidebar
-        class="layout-sidebar"
-        :items="navItems"
-        :active-path="activePath"
-        @navigate="handleNavigate"
-      />
-      <main class="layout-main">
-        <RouterView />
-      </main>
-    </div>
-  </div>
+  <v-app>
+    <AppHeader :dark="dark" @toggle-theme="toggleTheme" @toggle-drawer="drawer = !drawer" />
+    <v-navigation-drawer v-model="drawer" :permanent="mdAndUp" :temporary="!mdAndUp" width="264" color="surface">
+      <AppSidebar :items="navItems" :active-path="activePath" @navigate="closeDrawer" />
+    </v-navigation-drawer>
+    <v-main>
+      <v-container fluid class="pa-4 pa-md-6 page-container"><RouterView /></v-container>
+    </v-main>
+    <v-dialog
+      v-model="confirmationDialog"
+      max-width="480"
+      aria-labelledby="confirmation-title"
+      aria-describedby="confirmation-message"
+      @click:outside="rejectConfirmation"
+    >
+      <v-card>
+        <v-card-title id="confirmation-title" class="d-flex align-center ga-2">
+          <v-icon v-if="confirmState.icon" :icon="confirmState.icon" />
+          <span>{{ confirmState.header || '确认操作' }}</span>
+          <v-spacer />
+          <v-btn
+            icon="mdi-close"
+            variant="text"
+            aria-label="关闭确认对话框"
+            @click="rejectConfirmation"
+          />
+        </v-card-title>
+        <v-card-text id="confirmation-message">{{ confirmState.message }}</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="rejectConfirmation">{{ confirmState.rejectLabel }}</v-btn>
+          <v-btn color="primary" @click="acceptConfirmation">{{ confirmState.acceptLabel }}</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+    <v-snackbar v-model="feedbackState.open" :color="feedbackState.severity" :timeout="feedbackState.life">
+      <strong v-if="feedbackState.summary">{{ feedbackState.summary }}：</strong>{{ feedbackState.detail }}
+    </v-snackbar>
+  </v-app>
 </template>

--- a/webui/src/components/ActivityTimeline.vue
+++ b/webui/src/components/ActivityTimeline.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import Timeline from 'primevue/timeline';
-import Card from 'primevue/card';
-import Tag from 'primevue/tag';
+import { normalizeVuetifyColor } from '@/composables/feedback';
 
 export interface ActivityEntry {
   message_id: number;
@@ -30,32 +28,42 @@ function scopeLabel(scope: string) {
 </script>
 
 <template>
-  <Timeline :value="props.entries" align="alternate" class="w-full">
-    <template #opposite="slotProps">
-      <span class="text-sm text-color-secondary">
-        {{ slotProps.item.sent_at ? new Date(slotProps.item.sent_at).toLocaleString() : '未知时间' }}
-      </span>
-    </template>
-    <template #marker="slotProps">
-      <span class="flex align-items-center justify-content-center w-2rem h-2rem border-circle bg-primary text-white">
-        <i class="pi pi-bolt"></i>
-      </span>
-    </template>
-    <template #content="slotProps">
-      <Card class="shadow-1">
-        <template #title>
-          <div class="flex align-items-center justify-content-between">
-            <span class="text-sm">消息 ID #{{ slotProps.item.message_id }}</span>
-            <Tag :value="scopeLabel(slotProps.item.scope).label" :severity="scopeLabel(slotProps.item.scope).severity" />
-          </div>
-        </template>
-        <template #content>
-          <div class="text-color-secondary text-sm">对象 ID：{{ slotProps.item.scope_id }}</div>
-          <p class="mt-2 mb-0 white-space-pre-line">
-            {{ slotProps.item.preview ?? '暂无文本内容' }}
-          </p>
-        </template>
-      </Card>
-    </template>
-  </Timeline>
+  <v-timeline class="w-100">
+    <v-timeline-item
+      v-for="entry in props.entries"
+      :key="entry.message_id"
+      dot-color="primary"
+      fill-dot
+    >
+      <template #opposite>
+        <span class="text-body-2 text-medium-emphasis">
+          {{ entry.sent_at ? new Date(entry.sent_at).toLocaleString() : '未知时间' }}
+        </span>
+      </template>
+      <template #icon>
+        <v-icon icon="mdi-flash" color="white" />
+      </template>
+      <template #default>
+        <v-card class="elevation-1">
+          <v-card-title>
+            <div class="d-flex align-center justify-space-between">
+              <span class="text-body-2">消息 ID #{{ entry.message_id }}</span>
+              <v-chip
+                :color="normalizeVuetifyColor(scopeLabel(entry.scope).severity)"
+                size="small"
+              >
+                {{ scopeLabel(entry.scope).label }}
+              </v-chip>
+            </div>
+          </v-card-title>
+          <v-card-text>
+            <div class="text-medium-emphasis text-body-2">对象 ID：{{ entry.scope_id }}</div>
+            <p class="mt-2 mb-0 white-space-pre-line">
+              {{ entry.preview ?? '暂无文本内容' }}
+            </p>
+          </v-card-text>
+        </v-card>
+      </template>
+    </v-timeline-item>
+  </v-timeline>
 </template>

--- a/webui/src/components/ActivityTimeline.vue
+++ b/webui/src/components/ActivityTimeline.vue
@@ -25,13 +25,17 @@ function scopeLabel(scope: string) {
       return { label: scope, severity: 'secondary' } as const;
   }
 }
+
+function activityKey(entry: ActivityEntry): string {
+  return `${entry.scope}:${entry.scope_id}:${entry.message_id}`;
+}
 </script>
 
 <template>
   <v-timeline class="w-100">
     <v-timeline-item
       v-for="entry in props.entries"
-      :key="entry.message_id"
+      :key="activityKey(entry)"
       dot-color="primary"
       fill-dot
     >

--- a/webui/src/components/AppHeader.vue
+++ b/webui/src/components/AppHeader.vue
@@ -1,41 +1,14 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-import Menubar from 'primevue/menubar';
-import type { MenuItem } from 'primevue/menuitem';
-
-interface NavItem {
-  label: string;
-  icon: string;
-  to: string;
-}
-
-const props = defineProps<{ items: NavItem[]; activePath: string }>();
-const emit = defineEmits<{ (e: 'navigate', to: string): void }>();
-
-const menuModel = computed<MenuItem[]>(() =>
-  props.items.map((item) => ({
-    label: item.label,
-    icon: item.icon,
-    command: () => emit('navigate', item.to),
-    class: { active: props.activePath.startsWith(item.to) }
-  }))
-);
+defineProps<{ dark: boolean }>();
+const emit = defineEmits<{ (e: 'toggle-theme'): void; (e: 'toggle-drawer'): void }>();
 </script>
 
 <template>
-  <header class="surface-card border-bottom-1 surface-border">
-    <Menubar :model="menuModel" class="max-w-full border-none">
-      <template #start>
-        <div class="flex align-items-center gap-2 pl-2">
-          <i class="pi pi-shield text-primary text-xl"></i>
-          <span class="font-semibold text-lg">ACG 图像管控后台</span>
-        </div>
-      </template>
-      <template #end>
-        <div class="pr-3 text-sm text-color-secondary">
-          数据实时刷新，保障多群运营。
-        </div>
-      </template>
-    </Menubar>
-  </header>
+  <v-app-bar flat border="b" color="surface">
+    <v-app-bar-nav-icon class="d-md-none" aria-label="打开导航菜单" @click="emit('toggle-drawer')" />
+    <v-icon icon="mdi-shield-star-outline" color="primary" class="ml-2" />
+    <v-app-bar-title>ACG 图像管控后台</v-app-bar-title>
+    <span class="text-body-2 text-medium-emphasis mr-3 d-none d-sm-inline">Material 3 控制台</span>
+    <v-btn icon="mdi-theme-light-dark" variant="text" :aria-label="dark ? '切换亮色主题' : '切换暗色主题'" @click="emit('toggle-theme')" />
+  </v-app-bar>
 </template>

--- a/webui/src/components/AppSidebar.vue
+++ b/webui/src/components/AppSidebar.vue
@@ -1,59 +1,22 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-import Listbox from 'primevue/listbox';
-
-interface NavItem {
-  label: string;
-  icon: string;
-  to: string;
-}
-
-const props = defineProps<{ items: NavItem[]; activePath: string }>();
-const emit = defineEmits<{ (e: 'navigate', to: string): void }>();
-
-interface SidebarOption {
-  to: string;
-  icon: string;
-  label: string;
-  value: string;
-}
-
-const options = computed<SidebarOption[]>(() =>
-  props.items.map((item) => ({
-    label: item.label,
-    value: item.to,
-    icon: item.icon,
-    to: item.to
-  }))
-);
-
-const selected = computed({
-  get: () => props.activePath,
-  set: (value: string) => emit('navigate', value)
-});
+interface NavItem { label: string; icon: string; to: string }
+defineProps<{ items: NavItem[]; activePath: string }>();
+const emit = defineEmits<{ (e: 'navigate'): void }>();
 </script>
 
 <template>
-  <aside class="h-full">
-    <div class="p-3 border-bottom-1 surface-border text-sm text-color-secondary">
-      控制台导航
-    </div>
-    <Listbox
-      v-model="selected"
-      :options="options"
-      optionLabel="label"
-      optionValue="value"
-      class="w-full border-none"
-    >
-      <template #option="{ option, selected }">
-        <div
-          class="flex align-items-center gap-2 px-3 py-2 border-round transition-colors"
-          :class="selected ? 'bg-primary-100 text-primary' : ''"
-        >
-          <i :class="[option.icon, 'text-lg']"></i>
-          <span class="font-medium">{{ option.label }}</span>
-        </div>
-      </template>
-    </Listbox>
-  </aside>
+  <v-list nav density="comfortable" class="pa-3">
+    <v-list-subheader>控制台导航</v-list-subheader>
+    <v-list-item
+      v-for="item in items"
+      :key="item.to"
+      :active="activePath.startsWith(item.to)"
+      color="primary"
+      rounded="lg"
+      :to="item.to"
+      :prepend-icon="item.icon"
+      :title="item.label"
+      @click="emit('navigate')"
+    />
+  </v-list>
 </template>

--- a/webui/src/components/GroupDetailDialog.vue
+++ b/webui/src/components/GroupDetailDialog.vue
@@ -1,15 +1,8 @@
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue';
-import Dialog from 'primevue/dialog';
-import InputSwitch from 'primevue/toggleswitch';
-import Dropdown from 'primevue/select';
-import Chips from 'primevue/inputtags';
-import Button from 'primevue/button';
-import Divider from 'primevue/divider';
-import Tag from 'primevue/tag';
-import Timeline from 'primevue/timeline';
 
 import type { GroupDetail, GroupMeta, GroupUpdatePayload } from '@/services/api';
+import { groupFormSnapshot, normalizeAdminIds } from '@/utils/dialog-form';
 
 const props = defineProps<{
   visible: boolean;
@@ -24,24 +17,21 @@ const emit = defineEmits<{
 
 const form = reactive<GroupUpdatePayload>({});
 
+function syncForm(group: GroupDetail | null) {
+  Object.keys(form).forEach((key) => delete (form as any)[key]);
+  Object.assign(form, groupFormSnapshot(group));
+}
+
 watch(
-  () => props.group,
-  (group) => {
-    if (!group) {
-      Object.keys(form).forEach((key) => delete (form as any)[key]);
-      return;
-    }
-    form.name = group.name;
-    form.enable = group.enable;
-    form.enable_chat = group.enable_chat;
-    form.chat_mode = group.chat_mode;
-    form.sanity_limit = group.sanity_limit;
-    form.allow_r18g = group.allow_r18g;
-    form.allow_setu = group.allow_setu;
-    form.admin_ids = [...group.admin_ids];
-  },
-  { immediate: true }
+  [() => props.group, () => props.visible],
+  ([group]) => syncForm(group),
+  { immediate: true },
 );
+
+const dialogModel = computed({
+  get: () => props.visible && Boolean(props.group),
+  set: (value) => emit('update:visible', value),
+});
 
 const recentMessages = computed(() => props.group?.recent_messages ?? []);
 
@@ -49,108 +39,112 @@ function close() {
   emit('update:visible', false);
 }
 
+function updateChatMode(value: string | null) {
+  form.chat_mode = value;
+}
+
 function save() {
-  const adminIds = (form.admin_ids ?? [])
-    .map((value) => (typeof value === 'number' ? value : Number.parseInt(String(value), 10)))
-    .filter((value) => Number.isFinite(value));
+  const adminIds = normalizeAdminIds(form.admin_ids);
 
   emit('submit', { ...form, admin_ids: adminIds });
 }
 </script>
 
 <template>
-  <Dialog
-    :visible="visible && !!group"
-    :modal="true"
-    header="群组详情"
-    style="width: min(800px, 95vw)"
-    @update:visible="emit('update:visible', $event)"
-  >
-    <template v-if="group">
-      <section class="grid gap-4">
-        <div class="col-12">
-          <h3 class="text-lg font-semibold mb-3">基础配置</h3>
-          <div class="grid formgrid p-fluid">
-            <div class="field col-12 md:col-6">
-              <label class="text-sm text-color-secondary">群名称</label>
-              <input v-model="form.name" type="text" class="p-inputtext" />
-            </div>
-            <div class="field col-12 md:col-6">
-              <label class="text-sm text-color-secondary">聊天模式</label>
-              <Dropdown
-                v-model="form.chat_mode"
-                :options="meta?.chat_modes ?? []"
-                optionLabel="label"
-                optionValue="value"
-                placeholder="选择聊天模式"
-              />
-            </div>
-            <div class="field col-6 md:col-3">
-              <label class="text-sm text-color-secondary">群启用</label>
-              <InputSwitch v-model="form.enable" />
-            </div>
-            <div class="field col-6 md:col-3">
-              <label class="text-sm text-color-secondary">允许聊天</label>
-              <InputSwitch v-model="form.enable_chat" />
-            </div>
-            <div class="field col-6 md:col-3">
-              <label class="text-sm text-color-secondary">允许涩图</label>
-              <InputSwitch v-model="form.allow_setu" />
-            </div>
-            <div class="field col-6 md:col-3">
-              <label class="text-sm text-color-secondary">允许 R18G</label>
-              <InputSwitch v-model="form.allow_r18g" />
-            </div>
-            <div class="field col-12 md:col-6">
-              <label class="text-sm text-color-secondary">理智值上限</label>
-              <input v-model.number="form.sanity_limit" type="number" class="p-inputtext" min="0" />
-            </div>
-            <div class="field col-12">
-              <label class="text-sm text-color-secondary">管理员 ID 列表</label>
-              <Chips v-model="form.admin_ids" separator="," />
+  <VDialog v-model="dialogModel" max-width="800" aria-labelledby="group-dialog-title">
+    <VCard v-if="group">
+      <VCardTitle id="group-dialog-title">群组详情</VCardTitle>
+      <VCardText>
+        <section class="d-flex flex-column ga-4">
+          <div>
+            <h3 class="text-h6 font-weight-bold mb-3">基础配置</h3>
+            <VRow>
+              <VCol cols="12" md="6" class="d-flex flex-column ga-2">
+                <label for="group-name" class="text-body-2 text-medium-emphasis">群名称</label>
+                <VTextField id="group-name" v-model="form.name" hide-details="auto" />
+              </VCol>
+              <VCol cols="12" md="6" class="d-flex flex-column ga-2">
+                <label for="group-chat-mode" class="text-body-2 text-medium-emphasis">聊天模式</label>
+                <VSelect
+                  id="group-chat-mode"
+                  :model-value="form.chat_mode"
+                  :items="meta?.chat_modes ?? []"
+                  item-title="label"
+                  item-value="value"
+                  placeholder="选择聊天模式"
+                  hide-details="auto"
+                  @update:modelValue="updateChatMode"
+                />
+              </VCol>
+              <VCol cols="6" md="3" class="d-flex flex-column ga-2">
+                <label for="group-enable" class="text-body-2 text-medium-emphasis">群启用</label>
+                <VSwitch id="group-enable" v-model="form.enable" color="primary" hide-details density="compact" />
+              </VCol>
+              <VCol cols="6" md="3" class="d-flex flex-column ga-2">
+                <label for="group-enable-chat" class="text-body-2 text-medium-emphasis">允许聊天</label>
+                <VSwitch id="group-enable-chat" v-model="form.enable_chat" color="primary" hide-details density="compact" />
+              </VCol>
+              <VCol cols="6" md="3" class="d-flex flex-column ga-2">
+                <label for="group-allow-setu" class="text-body-2 text-medium-emphasis">允许涩图</label>
+                <VSwitch id="group-allow-setu" v-model="form.allow_setu" color="primary" hide-details density="compact" />
+              </VCol>
+              <VCol cols="6" md="3" class="d-flex flex-column ga-2">
+                <label for="group-allow-r18g" class="text-body-2 text-medium-emphasis">允许 R18G</label>
+                <VSwitch id="group-allow-r18g" v-model="form.allow_r18g" color="primary" hide-details density="compact" />
+              </VCol>
+              <VCol cols="12" md="6" class="d-flex flex-column ga-2">
+                <label for="group-sanity-limit" class="text-body-2 text-medium-emphasis">理智值上限</label>
+                <VNumberInput id="group-sanity-limit" v-model="form.sanity_limit" :min="0" hide-details="auto" />
+              </VCol>
+              <VCol cols="12" class="d-flex flex-column ga-2">
+                <label for="group-admin-ids" class="text-body-2 text-medium-emphasis">管理员 ID 列表</label>
+                <VCombobox
+                  id="group-admin-ids"
+                  v-model="form.admin_ids"
+                  multiple
+                  chips
+                  :delimiters="[',']"
+                  hide-details="auto"
+                />
+              </VCol>
+            </VRow>
+          </div>
+          <VDivider />
+          <div>
+            <h3 class="text-h6 font-weight-bold mb-3">运行状态</h3>
+            <div class="d-flex ga-3 flex-wrap">
+              <VChip size="small" color="info">群 ID #{{ group.id }}</VChip>
+              <VChip size="small" color="info">状态 {{ group.status }}</VChip>
+              <VChip size="small" color="success">消息量 {{ group.message_count }}</VChip>
+              <VChip size="small" color="warning">
+                最后活跃 {{ group.last_activity ? new Date(group.last_activity).toLocaleString() : '暂无' }}
+              </VChip>
             </div>
           </div>
-        </div>
-        <Divider />
-        <div class="col-12">
-          <h3 class="text-lg font-semibold mb-3">运行状态</h3>
-          <div class="flex gap-3 flex-wrap">
-            <Tag :value="`群 ID #${group.id}`" severity="info" />
-            <Tag :value="`状态 ${group.status}`" severity="help" />
-            <Tag :value="`消息量 ${group.message_count}`" severity="success" />
-            <Tag
-              :value="`最后活跃 ${group.last_activity ? new Date(group.last_activity).toLocaleString() : '暂无'}`"
-              severity="warning"
-            />
-          </div>
-        </div>
-        <Divider />
-        <div class="col-12">
-          <h3 class="text-lg font-semibold mb-3">近期消息</h3>
-          <Timeline :value="recentMessages" layout="vertical" align="left">
-            <template #marker>
-              <i class="pi pi-comment text-primary"></i>
-            </template>
-            <template #content="{ item }">
-              <div class="border-round surface-card p-3 shadow-1">
-                <div class="flex justify-content-between text-sm text-color-secondary">
-                  <span>消息 ID: {{ item.message_id }}</span>
-                  <span>{{ item.sent_at ? new Date(item.sent_at).toLocaleString() : '未知' }}</span>
+          <VDivider />
+          <div>
+            <h3 class="text-h6 font-weight-bold mb-3">近期消息</h3>
+            <VTimeline direction="vertical" align="start" density="compact">
+              <VTimelineItem v-for="item in recentMessages" :key="item.message_id">
+                <template #icon>
+                  <VIcon icon="mdi-comment-outline" color="primary" />
+                </template>
+                <div class="rounded-lg surface-panel p-3 elevation-1">
+                  <div class="d-flex justify-space-between text-body-2 text-medium-emphasis">
+                    <span>消息 ID: {{ item.message_id }}</span>
+                    <span>{{ item.sent_at ? new Date(item.sent_at).toLocaleString() : '未知' }}</span>
+                  </div>
+                  <p class="mt-2 mb-0 white-space-pre-line text-body-2">{{ item.text ?? '无内容' }}</p>
                 </div>
-                <p class="mt-2 mb-0 white-space-pre-line text-sm">
-                  {{ item.text ?? '无内容' }}
-                </p>
-              </div>
-            </template>
-          </Timeline>
-        </div>
-      </section>
-    </template>
-    <template #footer>
-      <div v-if="group" class="flex justify-content-end gap-2">
-        <Button label="取消" severity="secondary" outlined @click="close" />
-        <Button label="保存" icon="pi pi-check" @click="save" />
-      </div>
-    </template>
-  </Dialog>
+              </VTimelineItem>
+            </VTimeline>
+          </div>
+        </section>
+      </VCardText>
+      <VCardActions class="justify-end ga-2">
+        <VBtn variant="outlined" color="secondary" @click="close">取消</VBtn>
+        <VBtn color="primary" prepend-icon="mdi-check" @click="save">保存</VBtn>
+      </VCardActions>
+    </VCard>
+  </VDialog>
 </template>

--- a/webui/src/components/PrivateUserDialog.vue
+++ b/webui/src/components/PrivateUserDialog.vue
@@ -1,14 +1,8 @@
 <script setup lang="ts">
-import { reactive, watch } from 'vue';
-import Dialog from 'primevue/dialog';
-import InputSwitch from 'primevue/toggleswitch';
-import Dropdown from 'primevue/select';
-import Button from 'primevue/button';
-import Tag from 'primevue/tag';
-import Divider from 'primevue/divider';
-import Timeline from 'primevue/timeline';
+import { computed, reactive, watch } from 'vue';
 
 import type { PrivateMeta, PrivateUserDetail, PrivateUserUpdatePayload } from '@/services/api';
+import { privateUserFormSnapshot } from '@/utils/dialog-form';
 
 const props = defineProps<{
   visible: boolean;
@@ -23,24 +17,28 @@ const emit = defineEmits<{
 
 const form = reactive<PrivateUserUpdatePayload>({});
 
+function syncForm(user: PrivateUserDetail | null) {
+  Object.keys(form).forEach((key) => delete (form as any)[key]);
+  Object.assign(form, privateUserFormSnapshot(user));
+}
+
 watch(
-  () => props.user,
-  (user) => {
-    if (!user) {
-      Object.keys(form).forEach((key) => delete (form as any)[key]);
-      return;
-    }
-    form.nick_name = user.nick_name;
-    form.enable_chat = user.enable_chat;
-    form.sanity_limit = user.sanity_limit;
-    form.allow_r18g = user.allow_r18g;
-    form.status = user.status;
-  },
-  { immediate: true }
+  [() => props.user, () => props.visible],
+  ([user]) => syncForm(user),
+  { immediate: true },
 );
+
+const dialogModel = computed({
+  get: () => props.visible && Boolean(props.user),
+  set: (value) => emit('update:visible', value),
+});
 
 function close() {
   emit('update:visible', false);
+}
+
+function updateStatus(value: string | null) {
+  form.status = value;
 }
 
 function save() {
@@ -49,84 +47,79 @@ function save() {
 </script>
 
 <template>
-  <Dialog
-    :visible="visible && !!user"
-    :modal="true"
-    header="私聊用户详情"
-    style="width: min(720px, 95vw)"
-    @update:visible="emit('update:visible', $event)"
-  >
-    <template v-if="user">
-      <section class="grid gap-4">
-        <div class="col-12">
-          <h3 class="text-lg font-semibold mb-3">基础信息</h3>
-          <div class="grid formgrid p-fluid">
-            <div class="field col-12 md:col-6">
-              <label class="text-sm text-color-secondary">昵称</label>
-              <input v-model="form.nick_name" type="text" class="p-inputtext" />
-            </div>
-            <div class="field col-12 md:col-6">
-              <label class="text-sm text-color-secondary">状态</label>
-              <Dropdown
-                v-model="form.status"
-                :options="meta?.statuses ?? []"
-                optionLabel="label"
-                optionValue="value"
-              />
-            </div>
-            <div class="field col-6">
-              <label class="text-sm text-color-secondary">允许聊天</label>
-              <InputSwitch v-model="form.enable_chat" />
-            </div>
-            <div class="field col-6">
-              <label class="text-sm text-color-secondary">允许 R18G</label>
-              <InputSwitch v-model="form.allow_r18g" />
-            </div>
-            <div class="field col-12 md:col-6">
-              <label class="text-sm text-color-secondary">理智值上限</label>
-              <input v-model.number="form.sanity_limit" type="number" min="0" class="p-inputtext" />
+  <VDialog v-model="dialogModel" max-width="720" aria-labelledby="private-dialog-title">
+    <VCard v-if="user">
+      <VCardTitle id="private-dialog-title">私聊用户详情</VCardTitle>
+      <VCardText>
+        <section class="d-flex flex-column ga-4">
+          <div>
+            <h3 class="text-h6 font-weight-bold mb-3">基础信息</h3>
+            <VRow>
+              <VCol cols="12" md="6" class="d-flex flex-column ga-2">
+                <label for="private-nick-name" class="text-body-2 text-medium-emphasis">昵称</label>
+                <VTextField id="private-nick-name" v-model="form.nick_name" hide-details="auto" />
+              </VCol>
+              <VCol cols="12" md="6" class="d-flex flex-column ga-2">
+                <label for="private-status" class="text-body-2 text-medium-emphasis">状态</label>
+                <VSelect
+                  id="private-status"
+                  :model-value="form.status"
+                  :items="meta?.statuses ?? []"
+                  item-title="label"
+                  item-value="value"
+                  hide-details="auto"
+                  @update:modelValue="updateStatus"
+                />
+              </VCol>
+              <VCol cols="6" class="d-flex flex-column ga-2">
+                <label for="private-enable-chat" class="text-body-2 text-medium-emphasis">允许聊天</label>
+                <VSwitch id="private-enable-chat" v-model="form.enable_chat" color="primary" hide-details density="compact" />
+              </VCol>
+              <VCol cols="6" class="d-flex flex-column ga-2">
+                <label for="private-allow-r18g" class="text-body-2 text-medium-emphasis">允许 R18G</label>
+                <VSwitch id="private-allow-r18g" v-model="form.allow_r18g" color="primary" hide-details density="compact" />
+              </VCol>
+              <VCol cols="12" md="6" class="d-flex flex-column ga-2">
+                <label for="private-sanity-limit" class="text-body-2 text-medium-emphasis">理智值上限</label>
+                <VNumberInput id="private-sanity-limit" v-model="form.sanity_limit" :min="0" hide-details="auto" />
+              </VCol>
+            </VRow>
+          </div>
+          <VDivider />
+          <div>
+            <h3 class="text-h6 font-weight-bold mb-3">运行指标</h3>
+            <div class="d-flex ga-3 flex-wrap">
+              <VChip size="small" color="info">用户 ID #{{ user.id }}</VChip>
+              <VChip size="small" color="success">消息量 {{ user.message_count }}</VChip>
+              <VChip size="small" color="warning">
+                最后活跃 {{ user.last_activity ? new Date(user.last_activity).toLocaleString() : '暂无' }}
+              </VChip>
             </div>
           </div>
-        </div>
-        <Divider />
-        <div class="col-12">
-          <h3 class="text-lg font-semibold mb-3">运行指标</h3>
-          <div class="flex gap-3 flex-wrap">
-            <Tag :value="`用户 ID #${user.id}`" severity="info" />
-            <Tag :value="`消息量 ${user.message_count}`" severity="success" />
-            <Tag
-              :value="`最后活跃 ${user.last_activity ? new Date(user.last_activity).toLocaleString() : '暂无'}`"
-              severity="warning"
-            />
-          </div>
-        </div>
-        <Divider />
-        <div class="col-12">
-          <h3 class="text-lg font-semibold mb-3">近期消息</h3>
-          <Timeline :value="user.recent_messages" layout="vertical" align="left">
-            <template #marker>
-              <i class="pi pi-inbox text-primary"></i>
-            </template>
-            <template #content="{ item }">
-              <div class="border-round surface-card p-3 shadow-1">
-                <div class="flex justify-content-between text-sm text-color-secondary">
-                  <span>消息 ID: {{ item.message_id }}</span>
-                  <span>{{ item.sent_at ? new Date(item.sent_at).toLocaleString() : '未知' }}</span>
+          <VDivider />
+          <div>
+            <h3 class="text-h6 font-weight-bold mb-3">近期消息</h3>
+            <VTimeline direction="vertical" align="start" density="compact">
+              <VTimelineItem v-for="item in user.recent_messages" :key="item.message_id">
+                <template #icon>
+                  <VIcon icon="mdi-inbox" color="primary" />
+                </template>
+                <div class="rounded-lg surface-panel p-3 elevation-1">
+                  <div class="d-flex justify-space-between text-body-2 text-medium-emphasis">
+                    <span>消息 ID: {{ item.message_id }}</span>
+                    <span>{{ item.sent_at ? new Date(item.sent_at).toLocaleString() : '未知' }}</span>
+                  </div>
+                  <p class="mt-2 mb-0 white-space-pre-line text-body-2">{{ item.text ?? '无内容' }}</p>
                 </div>
-                <p class="mt-2 mb-0 white-space-pre-line text-sm">
-                  {{ item.text ?? '无内容' }}
-                </p>
-              </div>
-            </template>
-          </Timeline>
-        </div>
-      </section>
-    </template>
-    <template #footer>
-      <div v-if="user" class="flex justify-content-end gap-2">
-        <Button label="取消" severity="secondary" outlined @click="close" />
-        <Button label="保存" icon="pi pi-check" @click="save" />
-      </div>
-    </template>
-  </Dialog>
+              </VTimelineItem>
+            </VTimeline>
+          </div>
+        </section>
+      </VCardText>
+      <VCardActions class="justify-end ga-2">
+        <VBtn variant="outlined" color="secondary" @click="close">取消</VBtn>
+        <VBtn color="primary" prepend-icon="mdi-check" @click="save">保存</VBtn>
+      </VCardActions>
+    </VCard>
+  </VDialog>
 </template>

--- a/webui/src/components/StatCard.vue
+++ b/webui/src/components/StatCard.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import Card from 'primevue/card';
-import Tag from 'primevue/tag';
+import { normalizeVuetifyColor } from '@/composables/feedback';
 
 const props = defineProps<{
   label: string;
@@ -12,18 +11,25 @@ const props = defineProps<{
 </script>
 
 <template>
-  <Card class="h-full shadow-2 border-round-lg">
-    <template #title>
-      <div class="flex align-items-center justify-content-between">
-        <span class="text-sm text-color-secondary">{{ props.label }}</span>
-        <Tag v-if="hint" :value="hint" :severity="accent ?? 'primary'" rounded />
+  <v-card class="h-100 elevation-2 rounded-lg">
+    <v-card-title>
+      <div class="d-flex align-center justify-space-between">
+        <span class="text-body-2 text-medium-emphasis">{{ props.label }}</span>
+        <v-chip v-if="hint" :color="normalizeVuetifyColor(accent ?? 'primary')" rounded="pill" size="small">
+          {{ hint }}
+        </v-chip>
       </div>
-    </template>
-    <template #content>
-      <div class="flex align-items-center gap-3 mt-2">
-        <i v-if="icon" :class="[icon, 'text-3xl', `text-${accent ?? 'primary'}`]"></i>
-        <span class="text-3xl font-semibold">{{ value }}</span>
+    </v-card-title>
+    <v-card-text>
+      <div class="d-flex align-center ga-3 mt-2">
+        <v-icon
+          v-if="icon"
+          :icon="icon"
+          :color="normalizeVuetifyColor(accent ?? 'primary')"
+          class="text-h4"
+        />
+        <span class="text-h4 font-weight-bold">{{ value }}</span>
       </div>
-    </template>
-  </Card>
+    </v-card-text>
+  </v-card>
 </template>

--- a/webui/src/composables/feedback.ts
+++ b/webui/src/composables/feedback.ts
@@ -1,0 +1,100 @@
+import { reactive } from 'vue';
+
+const defaultConfirmationHeader = '确认操作';
+
+type ConfirmationCallback = () => void;
+
+export interface ConfirmationPayload {
+  message?: string;
+  header?: string;
+  icon?: string;
+  acceptLabel?: string;
+  rejectLabel?: string;
+  accept?: ConfirmationCallback;
+  reject?: ConfirmationCallback;
+}
+
+interface ConfirmationState {
+  open: boolean;
+  message: string;
+  header: string;
+  icon: string;
+  acceptLabel: string;
+  rejectLabel: string;
+  accept?: ConfirmationCallback;
+  reject?: ConfirmationCallback;
+}
+
+export const feedbackState = reactive({
+  open: false,
+  severity: 'info',
+  summary: '',
+  detail: '',
+  life: 3500
+});
+
+export const confirmState = reactive<ConfirmationState>({
+  open: false,
+  message: '',
+  header: defaultConfirmationHeader,
+  icon: '',
+  acceptLabel: '确认',
+  rejectLabel: '取消',
+  accept: undefined,
+  reject: undefined
+});
+
+export function normalizeVuetifyColor(color: string): string {
+  if (color === 'danger') return 'error';
+  if (color === 'warn') return 'warning';
+  if (color === 'help') return 'info';
+  return color;
+}
+
+export function closeConfirmation() {
+  confirmState.open = false;
+  confirmState.accept = undefined;
+  confirmState.reject = undefined;
+}
+
+function resolveConfirmation(callback?: ConfirmationCallback) {
+  closeConfirmation();
+  callback?.();
+}
+
+export function acceptConfirmation() {
+  resolveConfirmation(confirmState.accept);
+}
+
+export function rejectConfirmation() {
+  resolveConfirmation(confirmState.reject);
+}
+
+export function useFeedback() {
+  return {
+    toast: {
+      add(payload: { severity?: string; summary?: string; detail?: string; life?: number }) {
+        feedbackState.severity = normalizeVuetifyColor(payload.severity ?? 'info');
+        feedbackState.summary = payload.summary ?? '';
+        feedbackState.detail = payload.detail ?? '';
+        feedbackState.life = payload.life ?? 3500;
+        feedbackState.open = true;
+      }
+    },
+    confirm: {
+      require(payload: ConfirmationPayload) {
+        confirmState.message = payload.message ?? '确认执行此操作？';
+        confirmState.header = payload.header?.trim() ? payload.header : defaultConfirmationHeader;
+        confirmState.icon = payload.icon ?? '';
+        confirmState.acceptLabel = payload.acceptLabel ?? '确认';
+        confirmState.rejectLabel = payload.rejectLabel ?? '取消';
+        confirmState.accept = payload.accept;
+        confirmState.reject = payload.reject;
+        confirmState.open = true;
+      },
+      close() {
+        closeConfirmation();
+      }
+    }
+  };
+}

--- a/webui/src/main.ts
+++ b/webui/src/main.ts
@@ -1,26 +1,24 @@
 import { createApp } from 'vue';
-import PrimeVue from 'primevue/config';
-import ToastService from 'primevue/toastservice';
-import ConfirmationService from 'primevue/confirmationservice';
-import Aura from '@primeuix/themes/aura';
+import { createVuetify } from 'vuetify';
+import { aliases, mdi } from 'vuetify/iconsets/mdi';
+import 'vuetify/styles';
+import '@mdi/font/css/materialdesignicons.css';
 
 import App from './App.vue';
 import router from './router';
-
-import 'primeflex/primeflex.css';
-import 'primeicons/primeicons.css';
 import '@/styles/main.css';
 
-const app = createApp(App);
-
-app.use(PrimeVue, {
-  ripple: true,
+const storedTheme = localStorage.getItem('acgimg-theme');
+const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const vuetify = createVuetify({
   theme: {
-    preset: Aura
-  }
+    defaultTheme: storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : systemDark ? 'dark' : 'light',
+    themes: {
+      light: { dark: false, colors: { primary: '#6750A4', secondary: '#625B71', surface: '#FFFBFE', background: '#FFFBFE' } },
+      dark: { dark: true, colors: { primary: '#D0BCFF', secondary: '#CCC2DC', surface: '#141218', background: '#141218' } }
+    }
+  },
+  icons: { defaultSet: 'mdi', aliases, sets: { mdi } }
 });
-app.use(ToastService);
-app.use(ConfirmationService);
-app.use(router);
 
-app.mount('#app');
+createApp(App).use(vuetify).use(router).mount('#app');

--- a/webui/src/services/api.ts
+++ b/webui/src/services/api.ts
@@ -42,14 +42,19 @@ export interface CommandHistoryItem {
 export interface CommandHistoryResponse {
   total: number;
   items: CommandHistoryItem[];
+  page: number;
+  page_size: number;
+  pages: number;
 }
 
 export interface CommandHistoryQuery {
   command?: string;
   user_id?: number;
   success?: boolean;
-  limit?: number;
-  offset?: number;
+  page?: number;
+  page_size?: number;
+  sort_by?: string;
+  sort_order?: 'asc' | 'desc';
 }
 
 export interface EnumOption {
@@ -89,6 +94,9 @@ export interface GroupListItem {
 export interface GroupListResponse {
   total: number;
   items: GroupListItem[];
+  page: number;
+  page_size: number;
+  pages: number;
 }
 
 export interface GroupDetail extends GroupListItem {
@@ -99,8 +107,10 @@ export interface GroupListQuery {
   q?: string;
   enable?: boolean;
   chat_enabled?: boolean;
-  limit?: number;
-  offset?: number;
+  page?: number;
+  page_size?: number;
+  sort_by?: string;
+  sort_order?: 'asc' | 'desc';
 }
 
 export interface GroupUpdatePayload {
@@ -140,6 +150,9 @@ export interface PrivateUserListItem {
 export interface PrivateUserListResponse {
   total: number;
   items: PrivateUserListItem[];
+  page: number;
+  page_size: number;
+  pages: number;
 }
 
 export interface PrivateUserDetail extends PrivateUserListItem {
@@ -150,8 +163,10 @@ export interface PrivateUserListQuery {
   q?: string;
   chat_enabled?: boolean;
   status?: string;
-  limit?: number;
-  offset?: number;
+  page?: number;
+  page_size?: number;
+  sort_by?: string;
+  sort_order?: 'asc' | 'desc';
 }
 
 export interface PrivateUserUpdatePayload {
@@ -193,6 +208,9 @@ export interface PixivTokenItem {
 export interface PixivTokenListResponse {
   total: number;
   items: PixivTokenItem[];
+  page: number;
+  page_size: number;
+  pages: number;
 }
 
 export interface IllustrationPreview {
@@ -256,6 +274,9 @@ export interface IllustrationImportTask {
 export interface IllustrationImportTaskListResponse {
   total: number;
   items: IllustrationImportTask[];
+  page: number;
+  page_size: number;
+  pages: number;
 }
 
 export interface ManualIllustrationPayload {
@@ -298,7 +319,7 @@ export async function getGroupDetail(id: number): Promise<GroupDetail> {
 }
 
 export async function updateGroup(id: number, payload: GroupUpdatePayload): Promise<GroupDetail> {
-  const { data } = await client.put<GroupDetail>(`/groups/${id}`, payload);
+  const { data } = await client.patch<GroupDetail>(`/groups/${id}`, payload);
   return data;
 }
 
@@ -321,7 +342,7 @@ export async function updatePrivateUser(
   id: number,
   payload: PrivateUserUpdatePayload
 ): Promise<PrivateUserDetail> {
-  const { data } = await client.put<PrivateUserDetail>(`/private/users/${id}`, payload);
+  const { data } = await client.patch<PrivateUserDetail>(`/private/users/${id}`, payload);
   return data;
 }
 
@@ -367,8 +388,8 @@ export async function reloadBotToken(): Promise<BotTokenInfo> {
   return data;
 }
 
-export async function listPixivTokens(): Promise<PixivTokenListResponse> {
-  const { data } = await client.get<PixivTokenListResponse>('/pixiv-tokens');
+export async function listPixivTokens(page = 1, pageSize = 25): Promise<PixivTokenListResponse> {
+  const { data } = await client.get<PixivTokenListResponse>('/pixiv-tokens', { params: { page, page_size: pageSize } });
   return data;
 }
 
@@ -388,7 +409,7 @@ export async function setPixivTokenEnabled(id: number, enabled: boolean): Promis
 }
 
 export async function setAllPixivTokensEnabled(enabled: boolean): Promise<PixivTokenListResponse> {
-  const { data } = await client.patch<PixivTokenListResponse>('/pixiv-tokens/enabled', { enabled });
+  const { data } = await client.patch<PixivTokenListResponse>('/pixiv-tokens', { enabled });
   return data;
 }
 
@@ -414,8 +435,8 @@ export async function importIllustration(
   return data;
 }
 
-export async function listIllustrationTasks(limit = 20): Promise<IllustrationImportTaskListResponse> {
-  const { data } = await client.get<IllustrationImportTaskListResponse>('/illustrations/tasks', { params: { limit } });
+export async function listIllustrationTasks(page = 1, pageSize = 20): Promise<IllustrationImportTaskListResponse> {
+  const { data } = await client.get<IllustrationImportTaskListResponse>('/illustrations/tasks', { params: { page, page_size: pageSize } });
   return data;
 }
 

--- a/webui/src/services/api.ts
+++ b/webui/src/services/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { collectAllPages } from '@/utils/table-options';
 
 const client = axios.create({
   baseURL: '/api',
@@ -391,6 +392,10 @@ export async function reloadBotToken(): Promise<BotTokenInfo> {
 export async function listPixivTokens(page = 1, pageSize = 25): Promise<PixivTokenListResponse> {
   const { data } = await client.get<PixivTokenListResponse>('/pixiv-tokens', { params: { page, page_size: pageSize } });
   return data;
+}
+
+export async function listAllPixivTokens(pageSize = 100): Promise<PixivTokenItem[]> {
+  return collectAllPages((page, size) => listPixivTokens(page, size), pageSize);
 }
 
 export async function addPixivToken(token: string, enabled: boolean): Promise<PixivTokenItem> {

--- a/webui/src/styles/main.css
+++ b/webui/src/styles/main.css
@@ -1,60 +1,15 @@
-:root {
-  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
-  background-color: var(--surface-ground);
-  color: var(--text-color);
+:root { font-family: Inter, Roboto, "Noto Sans SC", sans-serif; }
+html, body, #app { min-height: 100%; margin: 0; }
+body { background: rgb(var(--v-theme-background)); }
+.page-container { max-width: 1600px; margin: 0 auto; }
+.section-heading { letter-spacing: -0.01em; }
+.data-table-card { overflow: hidden; }
+.clickable-row { cursor: pointer; }
+.white-space-pre-line { white-space: pre-line; }
+.surface-panel { background: rgb(var(--v-theme-surface)); }
+.token-code {
+  background-color: color-mix(in srgb, rgb(var(--v-theme-primary)) 20%, transparent);
+  border: 1px solid color-mix(in srgb, rgb(var(--v-theme-primary)) 35%, transparent);
+  color: rgb(var(--v-theme-on-surface));
 }
-
-body {
-  margin: 0;
-  min-height: 100vh;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-#app {
-  min-height: 100vh;
-}
-
-.p-menubar-root-list > .p-menuitem.active > .p-menuitem-content {
-  background: color-mix(in srgb, var(--primary-color) 15%, transparent);
-}
-
-.layout-shell {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
-
-.layout-content {
-  display: flex;
-  flex: 1;
-  min-height: 0;
-}
-
-.layout-sidebar {
-  width: 16rem;
-  border-right: 1px solid var(--surface-border);
-  background: var(--surface-card);
-}
-
-.layout-main {
-  flex: 1;
-  min-height: 0;
-  padding: 1.5rem;
-  background: var(--surface-ground);
-}
-
-@media (max-width: 960px) {
-  .layout-content {
-    flex-direction: column;
-  }
-
-  .layout-sidebar {
-    width: 100%;
-    border-right: 0;
-    border-bottom: 1px solid var(--surface-border);
-  }
-}
+.selected-task-row { background: rgb(var(--v-theme-surface-variant)); }

--- a/webui/src/utils/command-history.ts
+++ b/webui/src/utils/command-history.ts
@@ -1,0 +1,7 @@
+export function parseCommandHistoryUserId(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return undefined;
+
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}

--- a/webui/src/utils/dialog-form.ts
+++ b/webui/src/utils/dialog-form.ts
@@ -1,0 +1,47 @@
+import type {
+  GroupDetail,
+  GroupUpdatePayload,
+  PrivateUserDetail,
+  PrivateUserUpdatePayload,
+} from '../services/api';
+
+export function groupFormSnapshot(group: GroupDetail | null): GroupUpdatePayload {
+  if (!group) return {};
+
+  return {
+    name: group.name,
+    enable: group.enable,
+    enable_chat: group.enable_chat,
+    chat_mode: group.chat_mode,
+    sanity_limit: group.sanity_limit,
+    allow_r18g: group.allow_r18g,
+    allow_setu: group.allow_setu,
+    admin_ids: [...group.admin_ids],
+  };
+}
+
+export function privateUserFormSnapshot(user: PrivateUserDetail | null): PrivateUserUpdatePayload {
+  if (!user) return {};
+
+  return {
+    nick_name: user.nick_name,
+    enable_chat: user.enable_chat,
+    sanity_limit: user.sanity_limit,
+    allow_r18g: user.allow_r18g,
+    status: user.status,
+  };
+}
+
+export function normalizeAdminIds(values: readonly unknown[] | null | undefined): number[] {
+  return (values ?? [])
+    .map((value) => {
+      if (typeof value === 'number') {
+        return Number.isSafeInteger(value) && value >= 0 ? value : null;
+      }
+      if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
+
+      const parsed = Number(value);
+      return Number.isSafeInteger(parsed) ? parsed : null;
+    })
+    .filter((value): value is number => value !== null);
+}

--- a/webui/src/utils/illustration-task-table.ts
+++ b/webui/src/utils/illustration-task-table.ts
@@ -1,0 +1,38 @@
+import type { DataTableHeader } from 'vuetify';
+
+import type { IllustrationImportTask } from '@/services/api';
+
+export type IllustrationTaskRowProps = {
+  class: string;
+  onClick: (event: MouseEvent) => void;
+};
+
+export function createIllustrationTaskHeaders(
+  tasks: readonly IllustrationImportTask[],
+): DataTableHeader<IllustrationImportTask>[] {
+  const headers: DataTableHeader<IllustrationImportTask>[] = [
+    { title: 'ID', key: 'id', sortable: false },
+    { title: 'Pixiv ID', key: 'pixiv_id', sortable: false },
+    { title: '标题', key: 'title', sortable: false },
+    { title: '状态', key: 'status', sortable: false },
+    { title: '进度', key: 'progress', sortable: false },
+    { title: '创建时间', key: 'created_at', sortable: false },
+  ];
+
+  if (tasks.some((task) => Boolean(task.error_message?.trim()))) {
+    headers.push({ title: '错误信息', key: 'error_message', sortable: false });
+  }
+
+  return headers;
+}
+
+export function createIllustrationTaskRowProps(
+  item: IllustrationImportTask,
+  selectedId: number | null,
+  onSelect: (item: IllustrationImportTask) => void,
+): IllustrationTaskRowProps {
+  return {
+    class: selectedId === item.id ? 'selected-task-row' : '',
+    onClick: (_event: MouseEvent) => onSelect(item),
+  };
+}

--- a/webui/src/utils/table-options.ts
+++ b/webui/src/utils/table-options.ts
@@ -11,6 +11,19 @@ export type ApiTableParams = {
   sort_order?: 'asc' | 'desc';
 };
 
+export async function collectAllPages<T>(
+  loadPage: (page: number, pageSize: number) => Promise<{ items: T[]; pages: number }>,
+  pageSize: number,
+): Promise<T[]> {
+  const items: T[] = [];
+
+  for (let page = 1; ; page += 1) {
+    const response = await loadPage(page, pageSize);
+    items.push(...response.items);
+    if (page >= response.pages || response.items.length === 0) return items;
+  }
+}
+
 export type ServerTableRequestGuard = {
   begin: (key: string) => number;
   isLatest: (requestId: number) => boolean;

--- a/webui/src/utils/table-options.ts
+++ b/webui/src/utils/table-options.ts
@@ -1,0 +1,65 @@
+export type ServerTableOptions = {
+  page: number;
+  itemsPerPage: number;
+  sortBy: ReadonlyArray<{ key: string; order?: 'asc' | 'desc' }>;
+};
+
+export type ApiTableParams = {
+  page: number;
+  page_size: number;
+  sort_by?: string;
+  sort_order?: 'asc' | 'desc';
+};
+
+export type ServerTableRequestGuard = {
+  begin: (key: string) => number;
+  isLatest: (requestId: number) => boolean;
+  shouldLoad: (key: string) => boolean;
+  invalidateFailed: (requestId: number) => void;
+};
+
+export function createServerTableRequestGuard(): ServerTableRequestGuard {
+  let latestRequestId = 0;
+  let lastLoadedOptionsKey: string | undefined;
+
+  return {
+    begin(key) {
+      const requestId = ++latestRequestId;
+      lastLoadedOptionsKey = key;
+      return requestId;
+    },
+    isLatest(requestId) {
+      return requestId === latestRequestId;
+    },
+    shouldLoad(key) {
+      return key !== lastLoadedOptionsKey;
+    },
+    invalidateFailed(requestId) {
+      if (requestId === latestRequestId) {
+        lastLoadedOptionsKey = undefined;
+      }
+    },
+  };
+}
+
+export function toApiTableParams(
+  options: ServerTableOptions,
+  supportedKeys: ReadonlyArray<string>,
+): ApiTableParams {
+  const params: ApiTableParams = {
+    page: options.page,
+    page_size: options.itemsPerPage,
+  };
+  const firstSort = options.sortBy[0];
+
+  if (
+    firstSort &&
+    supportedKeys.includes(firstSort.key) &&
+    (firstSort.order === 'asc' || firstSort.order === 'desc')
+  ) {
+    params.sort_by = firstSort.key;
+    params.sort_order = firstSort.order;
+  }
+
+  return params;
+}

--- a/webui/src/views/BotTokensView.vue
+++ b/webui/src/views/BotTokensView.vue
@@ -1,16 +1,6 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
-import Card from 'primevue/card';
-import InputSwitch from 'primevue/toggleswitch';
-import Tag from 'primevue/tag';
-import Button from 'primevue/button';
-import Toast from 'primevue/toast';
-import Dialog from 'primevue/dialog';
-import InputText from 'primevue/inputtext';
-import ConfirmDialog from 'primevue/confirmdialog';
-import Skeleton from 'primevue/skeleton';
-import { useToast } from 'primevue/usetoast';
-import { useConfirm } from 'primevue/useconfirm';
+import { computed, onMounted, ref } from 'vue';
+import { useFeedback } from '@/composables/feedback';
 
 import type { BotTokenInfo } from '@/services/api';
 import {
@@ -21,8 +11,7 @@ import {
   reloadBotToken
 } from '@/services/api';
 
-const toast = useToast();
-const confirm = useConfirm();
+const { toast, confirm } = useFeedback();
 
 const loading = ref(true);
 const saving = ref(false);
@@ -32,6 +21,13 @@ const dialogVisible = ref(false);
 const dialogToken = ref('');
 const dialogEnabled = ref(true);
 const showFullToken = ref(false);
+
+const dialogModel = computed({
+  get: () => dialogVisible.value,
+  set: (value: boolean) => {
+    dialogVisible.value = value;
+  },
+});
 
 const editing = ref(false);
 
@@ -64,7 +60,7 @@ function openEdit() {
 async function save() {
   const token = dialogToken.value.trim();
   if (!token) {
-    toast.add({ severity: 'warn', summary: '无效输入', detail: 'Bot Token 不能为空。', life: 3000 });
+    toast.add({ severity: 'warning', summary: '无效输入', detail: 'Bot Token 不能为空。', life: 3000 });
     return;
   }
   saving.value = true;
@@ -84,13 +80,14 @@ async function save() {
   }
 }
 
-async function toggleEnabled(value: boolean) {
+async function toggleEnabled(value: boolean | null) {
+  const enabled = value ?? false;
   try {
-    info.value = await setBotTokenEnabled(value);
+    info.value = await setBotTokenEnabled(enabled);
     toast.add({
       severity: 'success',
       summary: '已更新',
-      detail: value ? 'Bot 已启用，点击“重新加载”使其生效。' : 'Bot 已停用，点击“重新加载”使其生效。'
+      detail: enabled ? 'Bot 已启用，点击“重新加载”使其生效。' : 'Bot 已停用，点击“重新加载”使其生效。'
     });
   } catch (error) {
     console.error(error);
@@ -102,7 +99,7 @@ function onDelete() {
   confirm.require({
     message: '确定要删除 Bot Token 吗？删除后 Telegram 集成将停止工作。',
     header: '删除确认',
-    icon: 'pi pi-exclamation-triangle',
+    icon: 'mdi-alert-outline',
     acceptLabel: '删除',
     rejectLabel: '取消',
     accept: async () => {
@@ -135,97 +132,95 @@ onMounted(load);
 </script>
 
 <template>
-  <section class="flex flex-column gap-4">
-    <Toast />
-    <ConfirmDialog />
-    <header class="flex flex-column gap-2">
-      <h2 class="text-2xl font-semibold m-0">Bot Token 管理</h2>
-      <p class="text-color-secondary m-0">
+  <section class="d-flex flex-column ga-4">
+    <header class="d-flex flex-column ga-2">
+      <h2 class="text-h5 font-weight-bold ma-0">Bot Token 管理</h2>
+      <p class="text-medium-emphasis ma-0">
         配置 Telegram Bot Token 与启用状态；修改后点击“重新加载”即可生效，无需重启后端。
       </p>
-      <div class="flex gap-2">
-        <Button label="刷新" icon="pi pi-refresh" outlined @click="load" :loading="loading" />
-        <Button label="配置" icon="pi pi-plus" :disabled="info?.configured" @click="openCreate" />
+      <div class="d-flex ga-2">
+        <VBtn prepend-icon="mdi-refresh" variant="outlined" @click="load" :loading="loading">刷新</VBtn>
+        <VBtn prepend-icon="mdi-plus" :disabled="info?.configured" @click="openCreate">配置</VBtn>
       </div>
     </header>
 
-    <Skeleton v-if="loading" height="12rem" class="border-round" />
+    <VSkeletonLoader v-if="loading" height="12rem" class="rounded-lg" />
 
-    <Card v-else class="shadow-1">
-      <template #title>
-        <div class="flex align-items-center justify-content-between">
+    <VCard v-else class="elevation-1">
+      <VCardTitle>
+        <div class="d-flex align-center justify-space-between">
           <span>Telegram Bot</span>
-          <Tag v-if="info?.configured" :value="info?.enabled ? '已启用' : '已停用'" :severity="info?.enabled ? 'success' : 'warning'" />
-          <Tag v-else value="未配置" severity="danger" />
+          <VChip v-if="info?.configured" size="small" :color="info?.enabled ? 'success' : 'warning'">{{ info?.enabled ? '已启用' : '已停用' }}</VChip>
+          <VChip v-else size="small" color="error">未配置</VChip>
         </div>
-      </template>
-      <template #content>
-        <div v-if="info?.configured" class="flex flex-column gap-4">
-          <div class="flex flex-column gap-2">
-            <span class="text-sm text-color-secondary">Bot Token</span>
-            <div class="flex align-items-center gap-2">
-              <code class="text-base bg-primary-50 px-3 py-2 border-round" style="word-break: break-all">
+      </VCardTitle>
+      <VCardText>
+        <div v-if="info?.configured" class="d-flex flex-column ga-4">
+          <div class="d-flex flex-column ga-2">
+            <span class="text-body-2 text-medium-emphasis">Bot Token</span>
+            <div class="d-flex align-center ga-2">
+              <code class="text-body-1 px-3 py-2 rounded-lg token-code" style="word-break: break-all">
                 {{ showFullToken ? info.token : info.masked }}
               </code>
-              <Button
-                :icon="showFullToken ? 'pi pi-eye-slash' : 'pi pi-eye'"
-                :label="showFullToken ? '隐藏' : '显示'"
-                text
-                severity="secondary"
+              <VBtn
+                :icon="showFullToken ? 'mdi-eye-off' : 'mdi-eye'"
+                variant="text"
+                color="secondary"
+                :aria-label="showFullToken ? '隐藏' : '显示'"
                 @click="showFullToken = !showFullToken"
               />
             </div>
           </div>
 
-          <div class="flex justify-content-between gap-3 align-items-center">
-            <div class="flex flex-column gap-1">
-              <span class="font-medium">启用 Bot</span>
-              <span class="text-sm text-color-secondary">停用后 Telegram 集成将停止接收消息。</span>
+          <div class="d-flex justify-space-between ga-3 align-center">
+            <div class="d-flex flex-column ga-1">
+              <span class="font-weight-medium">启用 Bot</span>
+              <span class="text-body-2 text-medium-emphasis">停用后 Telegram 集成将停止接收消息。</span>
             </div>
-            <InputSwitch :modelValue="info.enabled ?? false" @update:modelValue="toggleEnabled" />
+            <VSwitch :model-value="info.enabled ?? false" color="primary" hide-details density="compact" @update:modelValue="toggleEnabled" />
           </div>
 
-          <div class="flex flex-wrap gap-2">
-            <Button label="重新加载" icon="pi pi-refresh" @click="onReload" />
-            <Button label="修改" icon="pi pi-pencil" outlined @click="openEdit" />
-            <Button label="删除" icon="pi pi-trash" severity="danger" outlined @click="onDelete" />
+          <div class="d-flex flex-wrap ga-2">
+            <VBtn prepend-icon="mdi-refresh" @click="onReload">重新加载</VBtn>
+            <VBtn prepend-icon="mdi-pencil" variant="outlined" @click="openEdit">修改</VBtn>
+            <VBtn prepend-icon="mdi-delete" color="error" variant="outlined" @click="onDelete">删除</VBtn>
           </div>
         </div>
 
-        <div v-else class="flex flex-column gap-3">
-          <p class="text-color-secondary m-0">
+        <div v-else class="d-flex flex-column ga-3">
+          <p class="text-medium-emphasis ma-0">
             尚未配置 Bot Token。点击右上角“配置”按钮设置 Telegram Bot Token。
           </p>
         </div>
-      </template>
-    </Card>
+      </VCardText>
+    </VCard>
 
-    <Dialog
-      v-model:visible="dialogVisible"
-      :header="editing ? '修改 Bot Token' : '配置 Bot Token'"
-      modal
-      :style="{ width: '28rem' }"
-    >
-      <div class="flex flex-column gap-4 p-2">
-        <div class="flex flex-column gap-2">
-          <label for="bot-token-input" class="font-medium">Bot Token</label>
-          <InputText
+    <VDialog v-model="dialogModel" max-width="448" aria-labelledby="bot-token-dialog-title">
+      <VCard>
+        <VCardTitle id="bot-token-dialog-title">{{ editing ? '修改 Bot Token' : '配置 Bot Token' }}</VCardTitle>
+        <VCardText>
+          <div class="d-flex flex-column ga-4">
+        <div class="d-flex flex-column ga-2">
+          <label for="bot-token-input" class="font-weight-medium">Bot Token</label>
+          <VTextField
             id="bot-token-input"
             v-model="dialogToken"
             placeholder="123456789:AA...（从 @BotFather 获取）"
             autocomplete="off"
-            class="w-full"
+            class="w-100"
           />
         </div>
-        <div class="flex justify-content-between gap-3 align-items-center">
-          <span class="font-medium">配置后立即启用</span>
-          <InputSwitch v-model="dialogEnabled" />
+        <div class="d-flex justify-space-between ga-3 align-center">
+          <span class="font-weight-medium">配置后立即启用</span>
+          <VSwitch v-model="dialogEnabled" color="primary" hide-details density="compact" />
         </div>
-        <div class="flex justify-content-end gap-2">
-          <Button label="取消" severity="secondary" outlined @click="dialogVisible = false" />
-          <Button label="保存" icon="pi pi-check" :loading="saving" @click="save" />
-        </div>
-      </div>
-    </Dialog>
+          </div>
+        </VCardText>
+        <VCardActions class="justify-end ga-2">
+          <VBtn color="secondary" variant="outlined" @click="dialogModel = false">取消</VBtn>
+          <VBtn prepend-icon="mdi-check" :loading="saving" @click="save">保存</VBtn>
+        </VCardActions>
+      </VCard>
+    </VDialog>
   </section>
 </template>

--- a/webui/src/views/CommandHistoryView.vue
+++ b/webui/src/views/CommandHistoryView.vue
@@ -1,50 +1,90 @@
 <script setup lang="ts">
 import { onMounted, reactive, ref } from 'vue';
-import DataTable from 'primevue/datatable';
-import Column from 'primevue/column';
-import InputText from 'primevue/inputtext';
-import Dropdown from 'primevue/select';
-import Button from 'primevue/button';
-import Tag from 'primevue/tag';
-import Toast from 'primevue/toast';
-import { useToast } from 'primevue/usetoast';
-import Skeleton from 'primevue/skeleton';
+import { useFeedback } from '@/composables/feedback';
+import type { DataTableHeader, DataTableSortItem } from 'vuetify';
 
 import type { CommandHistoryItem, CommandHistoryQuery } from '@/services/api';
 import { listCommandHistory } from '@/services/api';
+import { parseCommandHistoryUserId } from '@/utils/command-history';
+import {
+  createServerTableRequestGuard,
+  toApiTableParams,
+  type ServerTableOptions,
+} from '@/utils/table-options';
 
-const toast = useToast();
+const { toast } = useFeedback();
 const loading = ref(true);
 const entries = ref<CommandHistoryItem[]>([]);
 
-const pagination = reactive({ page: 0, rows: 20, total: 0 });
+type NativeTableOptions = {
+  page: number;
+  itemsPerPage: number;
+  sortBy: ReadonlyArray<DataTableSortItem>;
+};
+
+const headers: DataTableHeader<CommandHistoryItem>[] = [
+  { title: '时间', key: 'triggered_at', sortable: true },
+  { title: '命令', key: 'command', sortable: true },
+  { title: '参数', key: 'arguments', sortable: false },
+  { title: '用户', key: 'user_id', sortable: false },
+  { title: '会话', key: 'chat_id', sortable: false },
+  { title: '结果', key: 'success', sortable: false },
+  { title: '耗时', key: 'duration_ms', sortable: false },
+  { title: '错误信息', key: 'error_message', sortable: false },
+];
+
+const pagination = reactive<ServerTableOptions & { total: number }>({
+  page: 1,
+  itemsPerPage: 20,
+  sortBy: [],
+  total: 0,
+});
 const filters = reactive<{ command: string; userId: string; success: boolean | null }>({
   command: '',
   userId: '',
   success: null
 });
 
-function parseUserId(): number | undefined {
-  const trimmed = filters.userId.trim();
-  if (!trimmed) return undefined;
-  const parsed = Number(trimmed);
-  return Number.isNaN(parsed) ? undefined : parsed;
+let tableReady = false;
+const requestGuard = createServerTableRequestGuard();
+
+function toServerTableOptions(options: NativeTableOptions): ServerTableOptions {
+  return {
+    page: options.page,
+    itemsPerPage: options.itemsPerPage,
+    sortBy: options.sortBy.map(({ key, order }) => ({
+      key,
+      ...(order === 'asc' || order === 'desc' ? { order } : {}),
+    })),
+  };
 }
 
-async function loadHistory() {
+function optionsKey(options: ServerTableOptions): string {
+  return JSON.stringify({
+    page: options.page,
+    itemsPerPage: options.itemsPerPage,
+    sortBy: options.sortBy,
+  });
+}
+
+async function loadHistory(options: ServerTableOptions = pagination) {
+  const requestId = requestGuard.begin(optionsKey(options));
   loading.value = true;
   try {
+    const tableParams = toApiTableParams(options, ['command', 'triggered_at']);
     const query: CommandHistoryQuery = {
       command: filters.command.trim() || undefined,
-      user_id: parseUserId(),
+      user_id: parseCommandHistoryUserId(filters.userId),
       success: filters.success === null ? undefined : filters.success,
-      limit: pagination.rows,
-      offset: pagination.page * pagination.rows
+      ...tableParams,
     };
     const { items, total } = await listCommandHistory(query);
+    if (!requestGuard.isLatest(requestId)) return;
     entries.value = items;
     pagination.total = total;
   } catch (error) {
+    if (!requestGuard.isLatest(requestId)) return;
+    requestGuard.invalidateFailed(requestId);
     console.error(error);
     toast.add({
       severity: 'error',
@@ -53,19 +93,29 @@ async function loadHistory() {
       life: 4000
     });
   } finally {
-    loading.value = false;
+    if (requestGuard.isLatest(requestId)) {
+      loading.value = false;
+    }
   }
 }
 
 function onSearch() {
-  pagination.page = 0;
-  loadHistory();
+  const options = { ...pagination, page: 1 };
+  pagination.page = 1;
+  void loadHistory(options);
 }
 
-function onPage(event: { page: number; rows: number }) {
-  pagination.page = event.page;
-  pagination.rows = event.rows;
-  loadHistory();
+function onTableOptions(nativeOptions: NativeTableOptions) {
+  if (!tableReady) return;
+
+  const options = toServerTableOptions(nativeOptions);
+  const key = optionsKey(options);
+  if (!requestGuard.shouldLoad(key)) return;
+
+  pagination.page = options.page;
+  pagination.itemsPerPage = options.itemsPerPage;
+  pagination.sortBy = options.sortBy;
+  void loadHistory(options);
 }
 
 function formatArguments(args: string[] | null): string {
@@ -84,107 +134,92 @@ function formatTimestamp(value: string): string {
   return date.toLocaleString();
 }
 
-onMounted(loadHistory);
+onMounted(async () => {
+  tableReady = true;
+  await loadHistory(pagination);
+});
 </script>
 
 <template>
-  <section class="flex flex-column gap-4">
-    <Toast />
-    <header class="flex flex-column gap-2">
-      <h2 class="text-2xl font-semibold m-0">命令历史</h2>
-      <p class="text-color-secondary m-0">
+  <section class="d-flex flex-column ga-4">
+    <header class="d-flex flex-column ga-2">
+      <h2 class="text-h5 font-weight-bold ma-0">命令历史</h2>
+      <p class="text-medium-emphasis ma-0">
         记录最近触发的机器人命令，帮助排查问题与追踪使用情况。
       </p>
-      <div class="grid align-items-end gap-3">
-        <div class="col-12 md:col-4">
-          <label class="block text-sm text-color-secondary mb-2">命令名称</label>
-          <InputText v-model="filters.command" placeholder="如 setu" class="w-full" @keydown.enter="onSearch" />
-        </div>
-        <div class="col-12 md:col-3">
-          <label class="block text-sm text-color-secondary mb-2">用户 ID</label>
-          <InputText v-model="filters.userId" placeholder="精准匹配" class="w-full" @keydown.enter="onSearch" />
-        </div>
-        <div class="col-6 md:col-3">
-          <label class="block text-sm text-color-secondary mb-2">执行状态</label>
-          <Dropdown
+      <VRow class="align-end ga-3">
+        <VCol cols="12" md="4">
+          <VTextField id="command-history-command" label="命令名称" v-model="filters.command" placeholder="如 setu" class="w-100" @keydown.enter="onSearch" />
+        </VCol>
+        <VCol cols="12" md="3">
+          <VTextField id="command-history-user-id" label="用户 ID" v-model="filters.userId" placeholder="精准匹配" class="w-100" @keydown.enter="onSearch" />
+        </VCol>
+        <VCol cols="6" md="3">
+          <VSelect
+            id="command-history-success"
+            label="执行状态"
             v-model="filters.success"
-            :options="[
+            :items="[
               { label: '全部', value: null },
               { label: '成功', value: true },
-              { label: '失败', value: false }
+              { label: '失败', value: false },
             ]"
-            optionLabel="label"
-            optionValue="value"
-            class="w-full"
-            @change="onSearch"
+            item-title="label"
+            item-value="value"
+            class="w-100"
+            @update:modelValue="onSearch"
           />
-        </div>
-        <div class="col-12 md:col-2 flex md:justify-content-end">
-          <Button label="查询" icon="pi pi-search" @click="onSearch" />
-        </div>
-      </div>
+        </VCol>
+        <VCol cols="12" md="2" class="d-flex justify-md-end">
+          <VBtn prepend-icon="mdi-magnify" @click="onSearch">查询</VBtn>
+        </VCol>
+      </VRow>
     </header>
 
-    <DataTable
+    <VDataTableServer
       v-if="entries.length || !loading"
-      :value="entries"
+      :headers="headers"
+      :items="entries"
       :loading="loading"
-      dataKey="id"
-      responsiveLayout="scroll"
-      :rows="pagination.rows"
-      :first="pagination.page * pagination.rows"
-      :totalRecords="pagination.total"
-      paginator
-      lazy
-      :rowsPerPageOptions="[20, 50, 100]"
-      @page="onPage"
-      class="shadow-1 border-round-xl"
+      item-value="id"
+      :page="pagination.page"
+      :items-length="pagination.total"
+      :items-per-page="pagination.itemsPerPage"
+      :items-per-page-options="[20, 50, 100]"
+      :sort-by="pagination.sortBy"
+      @update:options="onTableOptions"
+      class="elevation-1 rounded-lg"
     >
-      <Column field="triggered_at" header="时间" sortable>
-        <template #body="{ data }">
-          {{ formatTimestamp(data.triggered_at) }}
-        </template>
-      </Column>
-      <Column field="command" header="命令" sortable />
-      <Column header="参数">
-        <template #body="{ data }">
-          {{ formatArguments(data.arguments) }}
-        </template>
-      </Column>
-      <Column header="用户">
-        <template #body="{ data }">
-          {{ data.user_id ?? '—' }}
-        </template>
-      </Column>
-      <Column header="会话">
-        <template #body="{ data }">
-          <div class="flex flex-column">
-            <span>{{ data.chat_id ?? '—' }}</span>
-            <small class="text-color-secondary">{{ data.chat_type ?? '未知' }}</small>
+      <template #item.triggered_at="{ item }">
+        {{ formatTimestamp(item.triggered_at) }}
+      </template>
+      <template #item.arguments="{ item }">
+        {{ formatArguments(item.arguments) }}
+      </template>
+      <template #item.user_id="{ item }">
+        {{ item.user_id ?? '—' }}
+      </template>
+      <template #item.chat_id="{ item }">
+          <div class="d-flex flex-column">
+            <span>{{ item.chat_id ?? '—' }}</span>
+            <small class="text-medium-emphasis">{{ item.chat_type ?? '未知' }}</small>
           </div>
-        </template>
-      </Column>
-      <Column header="结果">
-        <template #body="{ data }">
-          <Tag :value="data.success ? '成功' : '失败'" :severity="data.success ? 'success' : 'danger'" />
-        </template>
-      </Column>
-      <Column header="耗时">
-        <template #body="{ data }">
-          {{ formatDuration(data.duration_ms) }}
-        </template>
-      </Column>
-      <Column header="错误信息" style="min-width: 16rem">
-        <template #body="{ data }">
-          <span class="text-sm">{{ data.error_message || '—' }}</span>
-        </template>
-      </Column>
-    </DataTable>
+      </template>
+      <template #item.success="{ item }">
+        <VChip :color="item.success ? 'success' : 'error'">{{ item.success ? '成功' : '失败' }}</VChip>
+      </template>
+      <template #item.duration_ms="{ item }">
+        {{ formatDuration(item.duration_ms) }}
+      </template>
+      <template #item.error_message="{ item }">
+        <span class="text-body-2">{{ item.error_message || '—' }}</span>
+      </template>
+    </VDataTableServer>
 
-    <div v-else class="grid">
-      <div class="col-12" v-for="index in 3" :key="index">
-        <Skeleton height="6rem" class="border-round" />
-      </div>
-    </div>
+    <VRow v-else>
+      <VCol cols="12" v-for="index in 3" :key="index">
+        <VSkeletonLoader height="6rem" class="rounded-lg" />
+      </VCol>
+    </VRow>
   </section>
 </template>

--- a/webui/src/views/DashboardView.vue
+++ b/webui/src/views/DashboardView.vue
@@ -1,18 +1,13 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
-import Card from 'primevue/card';
-import Skeleton from 'primevue/skeleton';
-import Button from 'primevue/button';
-import Divider from 'primevue/divider';
-import Toast from 'primevue/toast';
-import { useToast } from 'primevue/usetoast';
+import { useFeedback } from '@/composables/feedback';
 
 import StatCard from '@/components/StatCard.vue';
 import ActivityTimeline from '@/components/ActivityTimeline.vue';
 import type { DashboardSummary } from '@/services/api';
 import { fetchDashboardSummary } from '@/services/api';
 
-const toast = useToast();
+const { toast } = useFeedback();
 const loading = ref(true);
 const summary = ref<DashboardSummary | null>(null);
 
@@ -37,97 +32,96 @@ onMounted(loadSummary);
 </script>
 
 <template>
-  <section class="flex flex-column gap-4">
-    <Toast />
-    <div class="flex align-items-center justify-content-between flex-wrap gap-3">
+  <section class="d-flex flex-column ga-4">
+    <div class="d-flex align-center justify-space-between flex-wrap ga-3">
       <div>
-        <h2 class="text-2xl font-semibold m-0">仪表盘</h2>
-        <p class="text-color-secondary mt-1 mb-0">
+        <h2 class="text-h5 font-weight-bold ma-0">仪表盘</h2>
+        <p class="text-medium-emphasis mt-1 mb-0">
           总览运营指标与最近消息动态。
         </p>
       </div>
-      <Button label="刷新" icon="pi pi-refresh" @click="loadSummary" :loading="loading" outlined />
+      <VBtn prepend-icon="mdi-refresh" variant="outlined" :loading="loading" @click="loadSummary">刷新</VBtn>
     </div>
 
-    <div class="grid" v-if="!loading && summary">
-      <div class="col-12 md:col-6 xl:col-3">
+    <VRow v-if="!loading && summary">
+      <VCol cols="12" md="6" xl="3">
         <StatCard
           label="总群组"
           :value="summary.total_groups"
-          icon="pi pi-building"
+          icon="mdi-office-building-outline"
           accent="primary"
           :hint="`${summary.active_groups} 个活跃`"
         />
-      </div>
-      <div class="col-12 md:col-6 xl:col-3">
+      </VCol>
+      <VCol cols="12" md="6" xl="3">
         <StatCard
           label="启用聊天的群"
           :value="summary.chat_enabled_groups"
-          icon="pi pi-microphone"
+          icon="mdi-microphone-outline"
           accent="success"
           :hint="`${summary.total_group_messages} 条群消息`"
         />
-      </div>
-      <div class="col-12 md:col-6 xl:col-3">
+      </VCol>
+      <VCol cols="12" md="6" xl="3">
         <StatCard
           label="用户数量"
           :value="summary.total_users"
-          icon="pi pi-user"
+          icon="mdi-account-outline"
           accent="primary"
           :hint="`${summary.chat_enabled_users} 可聊天`"
         />
-      </div>
-      <div class="col-12 md:col-6 xl:col-3">
+      </VCol>
+      <VCol cols="12" md="6" xl="3">
         <StatCard
           label="私聊消息"
           :value="summary.total_private_messages"
-          icon="pi pi-envelope"
+          icon="mdi-email-outline"
           accent="warning"
           :hint="`近 ${summary.recent_activity.length} 条动态`"
         />
-      </div>
-    </div>
+      </VCol>
+    </VRow>
 
-    <div v-else class="grid">
-      <div class="col-12 md:col-6 xl:col-3" v-for="index in 4" :key="index">
-        <Skeleton height="12rem" class="border-round-xl" />
-      </div>
-    </div>
+    <VRow v-else>
+      <VCol cols="12" md="6" xl="3" v-for="index in 4" :key="index">
+        <VSkeletonLoader height="12rem" class="rounded-lg" />
+      </VCol>
+    </VRow>
 
-    <Card class="shadow-1">
-      <template #title>消息动态</template>
-      <template #content>
+    <VCard class="elevation-1">
+      <VCardTitle>消息动态</VCardTitle>
+      <VCardText>
         <template v-if="summary && summary.recent_activity.length">
           <ActivityTimeline :entries="summary.recent_activity" />
         </template>
         <template v-else-if="loading">
-          <div class="grid">
-            <div class="col-12" v-for="index in 3" :key="index">
-              <Skeleton height="6rem" class="border-round" />
-            </div>
-          </div>
+          <VRow>
+            <VCol cols="12" v-for="index in 3" :key="index">
+              <VSkeletonLoader height="6rem" class="rounded-lg" />
+            </VCol>
+          </VRow>
         </template>
         <template v-else>
-          <div class="text-center py-6 text-color-secondary">
+          <div class="text-center py-6 text-medium-emphasis">
             暂无最新消息，系统保持稳定运行。
           </div>
         </template>
-      </template>
-    </Card>
+      </VCardText>
+    </VCard>
 
-    <Card class="shadow-1">
-      <template #title>运营建议</template>
-      <template #content>
-        <p class="text-sm text-color-secondary mb-3">
+    <VCard class="elevation-1">
+      <VCardTitle>运营建议</VCardTitle>
+      <VCardText>
+        <p class="text-body-2 text-medium-emphasis mb-3">
           根据最近的消息分布，建议关注以下重点：
         </p>
-        <Divider />
-        <ul class="m-0 pl-3 text-sm">
+        <VDivider />
+        <ul class="ma-0 pl-3 text-body-2">
           <li>监控消息量激增的群组，合理设置理智值上限。</li>
           <li>私聊活跃用户可适当启用更多功能，增强粘性。</li>
           <li>预留功能配置已准备就绪，可随业务升级逐步开放。</li>
         </ul>
-      </template>
-    </Card>
+      </VCardText>
+    </VCard>
   </section>
 </template>

--- a/webui/src/views/FeatureConfigView.vue
+++ b/webui/src/views/FeatureConfigView.vue
@@ -1,17 +1,11 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
-import Card from 'primevue/card';
-import InputSwitch from 'primevue/toggleswitch';
-import Tag from 'primevue/tag';
-import Button from 'primevue/button';
-import Toast from 'primevue/toast';
-import { useToast } from 'primevue/usetoast';
-import Skeleton from 'primevue/skeleton';
+import { useFeedback } from '@/composables/feedback';
 
 import type { FeatureFlag, FeatureFlagResponse } from '@/services/api';
 import { fetchFeatureFlags, updateFeatureFlag } from '@/services/api';
 
-const toast = useToast();
+const { toast } = useFeedback();
 const loading = ref(true);
 const features = ref<FeatureFlag[]>([]);
 const placeholders = ref<FeatureFlag[]>([]);
@@ -57,77 +51,79 @@ onMounted(loadFlags);
 </script>
 
 <template>
-  <section class="flex flex-column gap-4">
-    <Toast />
-    <header class="flex flex-column gap-2">
-      <h2 class="text-2xl font-semibold m-0">功能配置</h2>
-      <p class="text-color-secondary m-0">
+  <section class="d-flex flex-column ga-4">
+    <header class="d-flex flex-column ga-2">
+      <h2 class="text-h5 font-weight-bold ma-0">功能配置</h2>
+      <p class="text-medium-emphasis ma-0">
         管理全局功能开关，并预留未来拓展的配置位。
       </p>
-      <Button label="刷新" icon="pi pi-refresh" outlined @click="loadFlags" :loading="loading" class="w-full md:w-auto" />
+      <VBtn prepend-icon="mdi-refresh" variant="outlined" @click="loadFlags" :loading="loading" class="w-100 w-md-auto">刷新</VBtn>
     </header>
 
-    <div v-if="loading" class="grid">
-      <div class="col-12 md:col-6" v-for="index in 4" :key="index">
-        <Skeleton height="8rem" class="border-round" />
-      </div>
-    </div>
+    <VRow v-if="loading">
+      <VCol cols="12" md="6" v-for="index in 4" :key="index">
+        <VSkeletonLoader height="8rem" class="rounded-lg" />
+      </VCol>
+    </VRow>
 
-    <div v-else class="grid gap-4">
-      <div class="col-12">
-        <h3 class="text-xl font-semibold mb-3">已上线功能</h3>
-        <div class="grid">
-          <div class="col-12 md:col-6" v-for="[category, items] in grouped" :key="category">
-            <Card class="shadow-1 h-full">
-              <template #title>
-                <div class="flex align-items-center justify-content-between">
+    <div v-else class="d-flex flex-column ga-4">
+      <div>
+        <h3 class="text-h6 font-weight-bold mb-3">已上线功能</h3>
+        <VRow>
+          <VCol cols="12" md="6" v-for="[category, items] in grouped" :key="category">
+            <VCard class="elevation-1 h-100">
+              <VCardTitle>
+                <div class="d-flex align-center justify-space-between">
                   <span>{{ category }}</span>
-                  <Tag value="可配置" severity="info" />
+                  <VChip size="small" color="info">可配置</VChip>
                 </div>
-              </template>
-              <template #content>
-                <div class="flex flex-column gap-3">
+              </VCardTitle>
+              <VCardText>
+                <div class="d-flex flex-column ga-3">
                   <div
                     v-for="item in items"
                     :key="item.key"
-                    class="flex justify-content-between gap-3 align-items-start"
+                    class="d-flex justify-space-between ga-3 align-start"
                   >
-                    <div class="flex flex-column gap-1">
-                      <span class="font-medium">{{ item.label }}</span>
-                      <span class="text-sm text-color-secondary">{{ item.description }}</span>
+                    <div class="d-flex flex-column ga-1">
+                      <span class="font-weight-medium">{{ item.label }}</span>
+                      <span class="text-body-2 text-medium-emphasis">{{ item.description }}</span>
                     </div>
-                    <InputSwitch
-                      :modelValue="item.value ?? false"
+                    <VSwitch
+                      :model-value="item.value ?? false"
+                      color="primary"
+                      hide-details
+                      density="compact"
                       :disabled="!item.editable"
-                      @update:modelValue="(value) => toggleFlag(item, value)"
+                      @update:modelValue="(value: boolean | null) => toggleFlag(item, value ?? false)"
                     />
                   </div>
                 </div>
-              </template>
-            </Card>
-          </div>
-        </div>
+              </VCardText>
+            </VCard>
+          </VCol>
+          </VRow>
       </div>
 
-      <div class="col-12">
-        <h3 class="text-xl font-semibold mb-3">预留能力</h3>
-        <div class="grid">
-          <div class="col-12 md:col-4" v-for="placeholder in placeholders" :key="placeholder.key">
-            <Card class="shadow-1 h-full">
-              <template #title>
-                <div class="flex align-items-center justify-content-between">
+      <div>
+        <h3 class="text-h6 font-weight-bold mb-3">预留能力</h3>
+        <VRow>
+          <VCol cols="12" md="4" v-for="placeholder in placeholders" :key="placeholder.key">
+            <VCard class="elevation-1 h-100">
+              <VCardTitle>
+                <div class="d-flex align-center justify-space-between">
                   <span>{{ placeholder.label }}</span>
-                  <Tag value="规划中" severity="warning" />
+                  <VChip size="small" color="warning">规划中</VChip>
                 </div>
-              </template>
-              <template #content>
-                <p class="text-sm text-color-secondary mb-0">
+              </VCardTitle>
+              <VCardText>
+                <p class="text-body-2 text-medium-emphasis mb-0">
                   {{ placeholder.description }}
                 </p>
-              </template>
-            </Card>
-          </div>
-        </div>
+              </VCardText>
+            </VCard>
+          </VCol>
+          </VRow>
       </div>
     </div>
   </section>

--- a/webui/src/views/GroupsView.vue
+++ b/webui/src/views/GroupsView.vue
@@ -1,14 +1,7 @@
 <script setup lang="ts">
 import { onMounted, reactive, ref } from 'vue';
-import DataTable from 'primevue/datatable';
-import Column from 'primevue/column';
-import InputText from 'primevue/inputtext';
-import Dropdown from 'primevue/select';
-import Button from 'primevue/button';
-import Tag from 'primevue/tag';
-import Toast from 'primevue/toast';
-import { useToast } from 'primevue/usetoast';
-import Skeleton from 'primevue/skeleton';
+import { useFeedback } from '@/composables/feedback';
+import type { DataTableHeader, DataTableSortItem } from 'vuetify';
 
 import GroupDetailDialog from '@/components/GroupDetailDialog.vue';
 import type {
@@ -25,20 +18,68 @@ import {
   listGroups,
   updateGroup
 } from '@/services/api';
+import {
+  createServerTableRequestGuard,
+  toApiTableParams,
+  type ServerTableOptions,
+} from '@/utils/table-options';
 
-const toast = useToast();
+const { toast } = useFeedback();
 const loading = ref(true);
 const groups = ref<GroupListItem[]>([]);
 const meta = ref<GroupMeta | null>(null);
 const detail = ref<GroupDetail | null>(null);
 const dialogVisible = ref(false);
 
-const pagination = reactive({ page: 0, rows: 10, total: 0 });
+type NativeTableOptions = {
+  page: number;
+  itemsPerPage: number;
+  sortBy: ReadonlyArray<DataTableSortItem>;
+};
+
+const headers: DataTableHeader<GroupListItem>[] = [
+  { title: '群 ID', key: 'id', sortable: true },
+  { title: '名称', key: 'name', sortable: true },
+  { title: '状态', key: 'enable', sortable: false },
+  { title: '聊天', key: 'enable_chat', sortable: false },
+  { title: '消息量', key: 'message_count', sortable: false },
+  { title: '最后活跃', key: 'last_activity', sortable: false },
+  { title: '操作', key: 'actions', sortable: false },
+];
+
+const pagination = reactive<ServerTableOptions & { total: number }>({
+  page: 1,
+  itemsPerPage: 10,
+  sortBy: [],
+  total: 0,
+});
 const filters = reactive<{ q: string; enable: boolean | null; chatEnabled: boolean | null }>({
   q: '',
   enable: null,
   chatEnabled: null
 });
+
+let tableReady = false;
+const requestGuard = createServerTableRequestGuard();
+
+function toServerTableOptions(options: NativeTableOptions): ServerTableOptions {
+  return {
+    page: options.page,
+    itemsPerPage: options.itemsPerPage,
+    sortBy: options.sortBy.map(({ key, order }) => ({
+      key,
+      ...(order === 'asc' || order === 'desc' ? { order } : {}),
+    })),
+  };
+}
+
+function optionsKey(options: ServerTableOptions): string {
+  return JSON.stringify({
+    page: options.page,
+    itemsPerPage: options.itemsPerPage,
+    sortBy: options.sortBy,
+  });
+}
 
 async function ensureMeta() {
   if (!meta.value) {
@@ -46,20 +87,24 @@ async function ensureMeta() {
   }
 }
 
-async function loadGroups() {
+async function loadGroups(options: ServerTableOptions = pagination) {
+  const requestId = requestGuard.begin(optionsKey(options));
   loading.value = true;
   try {
+    const tableParams = toApiTableParams(options, ['id', 'name']);
     const query: GroupListQuery = {
       q: filters.q || undefined,
       enable: filters.enable === null ? undefined : filters.enable,
       chat_enabled: filters.chatEnabled === null ? undefined : filters.chatEnabled,
-      limit: pagination.rows,
-      offset: pagination.page * pagination.rows
+      ...tableParams,
     };
     const response: GroupListResponse = await listGroups(query);
+    if (!requestGuard.isLatest(requestId)) return;
     groups.value = response.items;
     pagination.total = response.total;
   } catch (error) {
+    if (!requestGuard.isLatest(requestId)) return;
+    requestGuard.invalidateFailed(requestId);
     console.error(error);
     toast.add({
       severity: 'error',
@@ -68,19 +113,29 @@ async function loadGroups() {
       life: 4000
     });
   } finally {
-    loading.value = false;
+    if (requestGuard.isLatest(requestId)) {
+      loading.value = false;
+    }
   }
 }
 
 function onSearch() {
-  pagination.page = 0;
-  loadGroups();
+  const options = { ...pagination, page: 1 };
+  pagination.page = 1;
+  void loadGroups(options);
 }
 
-function onPage(event: { page: number; rows: number }) {
-  pagination.page = event.page;
-  pagination.rows = event.rows;
-  loadGroups();
+function onTableOptions(nativeOptions: NativeTableOptions) {
+  if (!tableReady) return;
+
+  const options = toServerTableOptions(nativeOptions);
+  const key = optionsKey(options);
+  if (!requestGuard.shouldLoad(key)) return;
+
+  pagination.page = options.page;
+  pagination.itemsPerPage = options.itemsPerPage;
+  pagination.sortBy = options.sortBy;
+  void loadGroups(options);
 }
 
 async function openDetail(groupId: number) {
@@ -105,6 +160,7 @@ async function handleUpdate(payload: GroupUpdatePayload) {
     const updated = await updateGroup(detail.value.id, payload);
     detail.value = updated;
     groups.value = groups.value.map((item) => (item.id === updated.id ? updated : item));
+    dialogVisible.value = false;
     toast.add({ severity: 'success', summary: '保存成功', detail: '群组配置已更新。', life: 2500 });
     await loadGroups();
   } catch (error) {
@@ -114,112 +170,107 @@ async function handleUpdate(payload: GroupUpdatePayload) {
 }
 
 onMounted(async () => {
-  await ensureMeta();
-  await loadGroups();
+  try {
+    await ensureMeta();
+  } catch (error) {
+    console.error(error);
+    toast.add({
+      severity: 'error',
+      summary: '加载失败',
+      detail: '无法获取群组元数据。',
+      life: 4000,
+    });
+  }
+  tableReady = true;
+  await loadGroups(pagination);
 });
 </script>
 
 <template>
-  <section class="flex flex-column gap-4">
-    <Toast />
-    <header class="flex flex-column gap-2">
-      <h2 class="text-2xl font-semibold m-0">群组管理</h2>
-      <p class="text-color-secondary m-0">
+  <section class="d-flex flex-column ga-4">
+    <header class="d-flex flex-column ga-2">
+      <h2 class="text-h5 font-weight-bold ma-0">群组管理</h2>
+      <p class="text-medium-emphasis ma-0">
         查看机器人所覆盖的群组，快速调整群级别的权限与配置。
       </p>
-      <div class="grid align-items-end gap-3">
-        <div class="col-12 md:col-4">
-          <label class="block text-sm text-color-secondary mb-2">搜索群 ID / 名称</label>
-          <span class="p-input-icon-left w-full">
-            <i class="pi pi-search" />
-            <InputText v-model="filters.q" placeholder="输入关键字" class="w-full" @keydown.enter="onSearch" />
-          </span>
-        </div>
-        <div class="col-6 md:col-3">
-          <label class="block text-sm text-color-secondary mb-2">启用状态</label>
-          <Dropdown
+      <VRow class="align-end ga-3">
+        <VCol cols="12" md="4">
+          <VTextField id="groups-search" label="搜索群 ID / 名称" v-model="filters.q" placeholder="输入关键字" prepend-inner-icon="mdi-magnify" class="w-100" @keydown.enter="onSearch" />
+        </VCol>
+        <VCol cols="6" md="3">
+          <VSelect
+            id="groups-enable"
+            label="启用状态"
             v-model="filters.enable"
-            :options="[
+            :items="[
               { label: '全部', value: null },
               { label: '已启用', value: true },
-              { label: '未启用', value: false }
+              { label: '未启用', value: false },
             ]"
-            optionLabel="label"
-            optionValue="value"
-            class="w-full"
-            @change="onSearch"
+            item-title="label"
+            item-value="value"
+            class="w-100"
+            @update:modelValue="onSearch"
           />
-        </div>
-        <div class="col-6 md:col-3">
-          <label class="block text-sm text-color-secondary mb-2">聊天功能</label>
-          <Dropdown
+        </VCol>
+        <VCol cols="6" md="3">
+          <VSelect
+            id="groups-chat-enabled"
+            label="聊天功能"
             v-model="filters.chatEnabled"
-            :options="[
+            :items="[
               { label: '全部', value: null },
               { label: '已开放', value: true },
-              { label: '已关闭', value: false }
+              { label: '已关闭', value: false },
             ]"
-            optionLabel="label"
-            optionValue="value"
-            class="w-full"
-            @change="onSearch"
+            item-title="label"
+            item-value="value"
+            class="w-100"
+            @update:modelValue="onSearch"
           />
-        </div>
-        <div class="col-12 md:col-2 flex md:justify-content-end">
-          <Button label="查询" icon="pi pi-filter" @click="onSearch" />
-        </div>
-      </div>
+        </VCol>
+        <VCol cols="12" md="2" class="d-flex justify-md-end">
+          <VBtn prepend-icon="mdi-filter-variant" @click="onSearch">查询</VBtn>
+        </VCol>
+      </VRow>
     </header>
 
-    <DataTable
-      :value="groups"
+    <VDataTableServer
+      :headers="headers"
+      :items="groups"
       :loading="loading"
-      dataKey="id"
-      responsiveLayout="scroll"
-      :rows="pagination.rows"
-      :first="pagination.page * pagination.rows"
-      :totalRecords="pagination.total"
-      paginator
-      lazy
-      :rowsPerPageOptions="[10, 20, 50]"
-      @page="onPage"
-      class="shadow-1 border-round-xl"
+      item-value="id"
+      :page="pagination.page"
+      :items-length="pagination.total"
+      :items-per-page="pagination.itemsPerPage"
+      :items-per-page-options="[10, 20, 50]"
+      :sort-by="pagination.sortBy"
+      @update:options="onTableOptions"
+      class="elevation-1 rounded-lg"
       v-if="groups.length || !loading"
     >
-      <Column field="id" header="群 ID" sortable />
-      <Column field="name" header="名称" sortable />
-      <Column header="状态">
-        <template #body="{ data }">
-          <Tag :value="data.enable ? '启用' : '停用'" :severity="data.enable ? 'success' : 'danger'" />
-        </template>
-      </Column>
-      <Column header="聊天">
-        <template #body="{ data }">
-          <Tag :value="data.enable_chat ? '开放' : '关闭'" :severity="data.enable_chat ? 'info' : 'warning'" />
-        </template>
-      </Column>
-      <Column header="消息量">
-        <template #body="{ data }">
-          <span class="font-medium">{{ data.message_count }}</span>
-        </template>
-      </Column>
-      <Column header="最后活跃">
-        <template #body="{ data }">
-          {{ data.last_activity ? new Date(data.last_activity).toLocaleString() : '暂无' }}
-        </template>
-      </Column>
-      <Column header="操作" style="width: 8rem">
-        <template #body="{ data }">
-          <Button label="详情" size="small" icon="pi pi-eye" @click="openDetail(data.id)" />
-        </template>
-      </Column>
-    </DataTable>
+      <template #item.enable="{ item }">
+        <VChip :color="item.enable ? 'success' : 'error'">{{ item.enable ? '启用' : '停用' }}</VChip>
+      </template>
+      <template #item.enable_chat="{ item }">
+        <VChip :color="item.enable_chat ? 'info' : 'warning'">{{ item.enable_chat ? '开放' : '关闭' }}</VChip>
+      </template>
+      <template #item.message_count="{ item }">
+        <span class="font-weight-medium">{{ item.message_count }}</span>
+      </template>
+      <template #item.last_activity="{ item }">
+        {{ item.last_activity ? new Date(item.last_activity).toLocaleString() : '暂无' }}
+      </template>
+      <template #item.actions="{ item }">
+        <VBtn size="small" variant="text" color="primary" prepend-icon="mdi-eye" @click="openDetail(item.id)">详情</VBtn>
+      </template>
+    </VDataTableServer>
 
-    <div v-else class="grid">
-      <div class="col-12" v-for="index in 3" :key="index">
-        <Skeleton height="7rem" class="border-round" />
-      </div>
-    </div>
+    <VRow v-else>
+      <VCol cols="12" v-for="index in 3" :key="index">
+        <VSkeletonLoader height="7rem" class="rounded-lg" />
+      </VCol>
+    </VRow>
 
     <GroupDetailDialog
       v-model:visible="dialogVisible"

--- a/webui/src/views/IllustrationImportView.vue
+++ b/webui/src/views/IllustrationImportView.vue
@@ -1,22 +1,11 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, computed } from 'vue';
-import Card from 'primevue/card';
-import Button from 'primevue/button';
-import InputText from 'primevue/inputtext';
-import Textarea from 'primevue/textarea';
-import InputNumber from 'primevue/inputnumber';
-import InputSwitch from 'primevue/toggleswitch';
-import Tag from 'primevue/tag';
-import Chip from 'primevue/chip';
-import ProgressBar from 'primevue/progressbar';
-import DataTable from 'primevue/datatable';
-import Column from 'primevue/column';
-import Toast from 'primevue/toast';
-import ConfirmDialog from 'primevue/confirmdialog';
-import Skeleton from 'primevue/skeleton';
-import Divider from 'primevue/divider';
-import { useToast } from 'primevue/usetoast';
-import { useConfirm } from 'primevue/useconfirm';
+import { useFeedback } from '@/composables/feedback';
+import type { DataTableHeader } from 'vuetify';
+import {
+  createIllustrationTaskHeaders,
+  createIllustrationTaskRowProps,
+} from '@/utils/illustration-task-table';
 
 import type {
   IllustrationPreview,
@@ -31,10 +20,10 @@ import {
   importManualIllustration
 } from '@/services/api';
 
-const toast = useToast();
-const confirm = useConfirm();
+const { toast, confirm } = useFeedback();
 
 const pixivIdInput = ref<number | null>(null);
+const pixivStep = ref(1);
 const loadingPreview = ref(false);
 const importing = ref(false);
 const preview = ref<IllustrationPreview | null>(null);
@@ -56,7 +45,7 @@ function chooseManualFile(event: Event) {
 
 async function submitManual() {
   if (!manualFile.value || !manualTitle.value.trim()) {
-    toast.add({ severity: 'warn', summary: '信息不完整', detail: '请选择图片并填写名称。', life: 3000 });
+    toast.add({ severity: 'warning', summary: '信息不完整', detail: '请选择图片并填写名称。', life: 3000 });
     return;
   }
   manualUploading.value = true;
@@ -73,7 +62,7 @@ async function submitManual() {
     manualSourceUrl.value = ''; manualAuthorUrl.value = ''; manualCaption.value = ''; manualTags.value = '';
     manualAi.value = false; manualR18.value = false; manualR18g.value = false;
   } catch (error: any) {
-    toast.add({ severity: 'error', summary: '添加失败', detail: error?.response?.data?.detail ?? '无法保存图片。', life: 5000 });
+    toast.add({ severity: 'error', summary: '添加失败', detail: error?.response?.data?.error?.message ?? error?.response?.data?.detail ?? '无法保存图片。', life: 5000 });
   } finally { manualUploading.value = false; }
 }
 
@@ -96,18 +85,20 @@ let retryTimer: number | null = null;
 let retryCount = 0;
 const MAX_RETRIES = 5;
 
+const headers = computed<DataTableHeader<IllustrationImportTask>[]>(() => createIllustrationTaskHeaders(tasks.value));
+
 const activeProgress = computed(() => {
   const task = activeTask.value;
   if (!task || !task.total_pages || task.total_pages <= 0) return 0;
   return Math.min(100, Math.round(((task.current_page ?? 0) / task.total_pages) * 100));
 });
 
-const statusSeverity = (status: string): 'success' | 'warning' | 'danger' | 'info' | 'secondary' => {
+const statusColor = (status: string): 'success' | 'warning' | 'error' | 'info' | 'secondary' => {
   switch (status) {
     case 'success':
       return 'success';
     case 'failed':
-      return 'danger';
+      return 'error';
     case 'running':
     case 'pending':
       return 'warning';
@@ -130,6 +121,10 @@ const statusLabel = (status: string): string => {
       return status;
   }
 };
+
+function taskRowProps({ item }: { item: IllustrationImportTask }) {
+  return createIllustrationTaskRowProps(item, selectedTask.value?.id ?? null, selectTask);
+}
 
 const formatTime = (value: string | null): string => {
   if (!value) return '-';
@@ -161,13 +156,14 @@ function applyPreview(data: IllustrationPreview) {
 async function loadPreview() {
   const pixivId = pixivIdInput.value;
   if (!pixivId) {
-    toast.add({ severity: 'warn', summary: '无效输入', detail: '请输入 Pixiv ID。', life: 3000 });
+    toast.add({ severity: 'warning', summary: '无效输入', detail: '请输入 Pixiv ID。', life: 3000 });
     return;
   }
   loadingPreview.value = true;
   try {
     const data = await previewIllustration(pixivId);
     applyPreview(data);
+    pixivStep.value = 2;
     toast.add({
       severity: data.exists ? 'info' : 'success',
       summary: data.exists ? '已存在' : '加载成功',
@@ -176,7 +172,7 @@ async function loadPreview() {
   } catch (error: any) {
     console.error(error);
     preview.value = null;
-    const detail = error?.response?.data?.detail ?? '无法加载该 Pixiv ID，请检查 Pixiv Token 配置。';
+    const detail = error?.response?.data?.error?.message ?? error?.response?.data?.detail ?? '无法加载该 Pixiv ID，请检查 Pixiv Token 配置。';
     toast.add({ severity: 'error', summary: '加载失败', detail, life: 5000 });
   } finally {
     loadingPreview.value = false;
@@ -185,10 +181,11 @@ async function loadPreview() {
 
 function onConfirmImport() {
   if (!preview.value) return;
+  pixivStep.value = 3;
   confirm.require({
     message: `确认导入 Pixiv ${preview.value.id}（共 ${preview.value.page_count} 页）？将下载原图并上传到存储服务。`,
     header: '确认导入',
-    icon: 'pi pi-download',
+    icon: 'mdi-download',
     acceptLabel: '导入',
     rejectLabel: '取消',
     accept: () => {
@@ -227,7 +224,7 @@ async function doImport() {
     startPolling(task.id);
   } catch (error: any) {
     console.error(error);
-    const detail = error?.response?.data?.detail ?? '创建导入任务失败，请稍后重试。';
+    const detail = error?.response?.data?.error?.message ?? error?.response?.data?.detail ?? '创建导入任务失败，请稍后重试。';
     toast.add({ severity: 'error', summary: '创建失败', detail, life: 5000 });
   } finally {
     importing.value = false;
@@ -279,7 +276,7 @@ function stopPolling() {
 async function loadTasks() {
   loadingTasks.value = true;
   try {
-    const response = await listIllustrationTasks(20);
+    const response = await listIllustrationTasks(1, 20);
     tasks.value = response.items;
     retryCount = 0;
   } catch (error) {
@@ -321,6 +318,7 @@ function selectTask(task: IllustrationImportTask) {
 
 function reset() {
   stopPolling();
+  pixivStep.value = 1;
   pixivIdInput.value = null;
   preview.value = null;
   activeTask.value = null;
@@ -335,213 +333,217 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <section class="flex flex-column gap-4">
-    <Toast />
-    <ConfirmDialog />
-    <header class="flex flex-column gap-2">
-      <h2 class="text-2xl font-semibold m-0">插画导入</h2>
-      <p class="text-color-secondary m-0">
+  <section class="d-flex flex-column ga-4">
+    <header class="d-flex flex-column ga-2">
+      <h2 class="text-h5 font-weight-bold ma-0">插画导入</h2>
+      <p class="text-medium-emphasis ma-0">
         输入 Pixiv ID 加载插画信息，可修改标题/描述/标签等字段后确认导入；导入在后台执行，进度显示在下方历史任务中。
       </p>
     </header>
 
-    <Card class="shadow-1">
-      <template #title>手动添加非 Pixiv 图片</template>
-      <template #subtitle>仅名称和图片为必填项；来源、作者及其链接均可留空。</template>
-      <template #content>
-        <div class="grid">
-          <div class="col-12 md:col-6 flex flex-column gap-2"><label>图片 *</label><input type="file" accept="image/jpeg,image/png,image/gif,image/webp" @change="chooseManualFile" /></div>
-          <div class="col-12 md:col-6 flex flex-column gap-2"><label>名称 *</label><InputText v-model="manualTitle" maxlength="64" /></div>
-          <div class="col-12 md:col-6 flex flex-column gap-2"><label>作者</label><InputText v-model="manualAuthor" /></div>
-          <div class="col-12 md:col-6 flex flex-column gap-2"><label>标签（逗号分隔）</label><InputText v-model="manualTags" /></div>
-          <div class="col-12 md:col-6 flex flex-column gap-2"><label>来源链接</label><InputText v-model="manualSourceUrl" type="url" placeholder="可留空" /></div>
-          <div class="col-12 md:col-6 flex flex-column gap-2"><label>作者链接</label><InputText v-model="manualAuthorUrl" type="url" placeholder="可留空" /></div>
-          <div class="col-12 flex flex-column gap-2"><label>描述</label><Textarea v-model="manualCaption" rows="2" /></div>
-          <div class="col-12 flex gap-4 flex-wrap">
-            <label class="flex align-items-center gap-2"><InputSwitch v-model="manualAi" /> AI</label>
-            <label class="flex align-items-center gap-2"><InputSwitch v-model="manualR18" /> R18</label>
-            <label class="flex align-items-center gap-2"><InputSwitch v-model="manualR18g" /> R18G</label>
-          </div>
-          <div class="col-12"><Button label="添加图片" icon="pi pi-upload" :loading="manualUploading" @click="submitManual" /></div>
-        </div>
-      </template>
-    </Card>
+    <VCard class="elevation-1">
+      <VCardTitle>手动添加非 Pixiv 图片</VCardTitle>
+      <VCardText>
+        <p class="text-body-2 text-medium-emphasis">仅名称和图片为必填项；来源、作者及其链接均可留空。</p>
+        <VRow>
+          <VCol cols="12" md="6" class="d-flex flex-column ga-2"><label>图片 *</label><input type="file" accept="image/jpeg,image/png,image/gif,image/webp" @change="chooseManualFile" /></VCol>
+          <VCol cols="12" md="6" class="d-flex flex-column ga-2"><label for="manual-title">名称 *</label><VTextField id="manual-title" v-model="manualTitle" maxlength="64" hide-details="auto" /></VCol>
+          <VCol cols="12" md="6" class="d-flex flex-column ga-2"><label for="manual-author">作者</label><VTextField id="manual-author" v-model="manualAuthor" hide-details="auto" /></VCol>
+          <VCol cols="12" md="6" class="d-flex flex-column ga-2"><label for="manual-tags">标签（逗号分隔）</label><VTextField id="manual-tags" v-model="manualTags" hide-details="auto" /></VCol>
+          <VCol cols="12" md="6" class="d-flex flex-column ga-2"><label for="manual-source-url">来源链接</label><VTextField id="manual-source-url" v-model="manualSourceUrl" type="url" placeholder="可留空" hide-details="auto" /></VCol>
+          <VCol cols="12" md="6" class="d-flex flex-column ga-2"><label for="manual-author-url">作者链接</label><VTextField id="manual-author-url" v-model="manualAuthorUrl" type="url" placeholder="可留空" hide-details="auto" /></VCol>
+          <VCol cols="12" class="d-flex flex-column ga-2"><label for="manual-caption">描述</label><VTextarea id="manual-caption" v-model="manualCaption" rows="2" hide-details="auto" /></VCol>
+          <VCol cols="12" class="d-flex ga-4 flex-wrap">
+            <label class="d-flex align-center ga-2"><VSwitch v-model="manualAi" color="primary" hide-details /> AI</label>
+            <label class="d-flex align-center ga-2"><VSwitch v-model="manualR18" color="primary" hide-details /> R18</label>
+            <label class="d-flex align-center ga-2"><VSwitch v-model="manualR18g" color="primary" hide-details /> R18G</label>
+          </VCol>
+          <VCol cols="12"><VBtn prepend-icon="mdi-upload" :loading="manualUploading" @click="submitManual">添加图片</VBtn></VCol>
+        </VRow>
+      </VCardText>
+    </VCard>
 
-    <Card class="shadow-1">
-      <template #content>
-        <div class="flex flex-column md:flex-row gap-3 align-items-center">
-          <InputNumber
+    <VCard class="elevation-1">
+      <VCardText>
+        <v-stepper v-model="pixivStep" alt-labels flat class="mb-4">
+          <v-stepper-header>
+            <v-stepper-item :value="1" title="选择来源" subtitle="输入 Pixiv ID" />
+            <v-divider />
+            <v-stepper-item :value="2" title="编辑元数据" subtitle="预览并调整" />
+            <v-divider />
+            <v-stepper-item :value="3" title="确认提交" subtitle="后台导入" />
+          </v-stepper-header>
+        </v-stepper>
+        <div class="d-flex flex-column flex-md-row ga-3 align-center">
+          <VNumberInput
             v-model="pixivIdInput"
             :min="1"
             placeholder="Pixiv ID，例如 12345678"
-            class="w-full md:w-20rem"
-            :useGrouping="false"
+            class="w-100"
+            style="max-width: 20rem"
+            hide-details="auto"
           />
-          <div class="flex gap-2 w-full md:w-auto">
-            <Button label="加载" icon="pi pi-search" :loading="loadingPreview" @click="loadPreview" />
-            <Button label="重置" icon="pi pi-times" outlined severity="secondary" @click="reset" />
+          <div class="d-flex ga-2 w-100 w-md-auto">
+            <VBtn prepend-icon="mdi-magnify" :loading="loadingPreview" @click="loadPreview">加载</VBtn>
+            <VBtn prepend-icon="mdi-close" variant="outlined" color="secondary" @click="reset">重置</VBtn>
           </div>
         </div>
-      </template>
-    </Card>
+      </VCardText>
+    </VCard>
 
-    <Skeleton v-if="loadingPreview" height="18rem" class="border-round" />
+    <VSkeletonLoader v-if="loadingPreview" height="18rem" class="rounded-lg" />
 
-    <Card v-else-if="preview" class="shadow-1">
-      <template #title>
-        <div class="flex align-items-center justify-content-between flex-wrap gap-2">
+    <VCard v-else-if="preview" class="elevation-1">
+      <VCardTitle>
+        <div class="d-flex align-center justify-space-between flex-wrap ga-2">
           <span>Pixiv {{ preview.id }}</span>
-          <div class="flex gap-2">
-            <Tag :value="preview.exists ? '已存在（将更新）' : '新插画'" :severity="preview.exists ? 'warning' : 'success'" />
-            <Tag v-if="preview.r18g" value="R18G" severity="danger" />
-            <Tag v-if="preview.is_ai" value="AI 作品" severity="info" />
+          <div class="d-flex ga-2">
+            <VChip size="small" :color="preview.exists ? 'warning' : 'success'">{{ preview.exists ? '已存在（将更新）' : '新插画' }}</VChip>
+            <VChip v-if="preview.r18g" size="small" color="error">R18G</VChip>
+            <VChip v-if="preview.is_ai" size="small" color="info">AI 作品</VChip>
           </div>
         </div>
-      </template>
-      <template #content>
-        <div class="flex flex-column gap-4">
-          <div class="flex flex-wrap gap-4 text-sm text-color-secondary">
+      </VCardTitle>
+      <VCardText>
+        <div class="d-flex flex-column ga-4">
+          <div class="d-flex flex-wrap ga-4 text-body-2 text-medium-emphasis">
             <span>作者：{{ preview.author_name }}（{{ preview.author_id }}）</span>
             <span>页数：{{ preview.page_count }}</span>
             <span>限制级：{{ preview.x_restrict }}</span>
           </div>
 
-          <div v-if="preview.preview_urls.length" class="flex flex-wrap gap-2">
+          <div v-if="preview.preview_urls.length" class="d-flex flex-wrap ga-2">
             <img
               v-for="(url, index) in preview.preview_urls"
               :key="index"
               :src="proxyImageUrl(url)"
               :alt="`第 ${index + 1} 页预览`"
-              class="border-round shadow-1"
+              class="rounded-lg elevation-1"
               style="max-width: 12rem; max-height: 12rem; object-fit: cover"
               loading="lazy"
             />
           </div>
 
-          <Divider />
+          <VDivider />
 
-          <div class="flex flex-column gap-4">
-            <div class="flex flex-column gap-2">
-              <label class="font-medium">标题</label>
-              <InputText v-model="editTitle" class="w-full" />
+          <div class="d-flex flex-column ga-4">
+            <div class="d-flex flex-column ga-2">
+              <label class="font-weight-medium">标题</label>
+              <VTextField v-model="editTitle" class="w-100" hide-details="auto" />
             </div>
-            <div class="flex flex-column gap-2">
-              <label class="font-medium">描述</label>
-              <Textarea v-model="editCaption" rows="4" class="w-full" />
+            <div class="d-flex flex-column ga-2">
+              <label class="font-weight-medium">描述</label>
+              <VTextarea v-model="editCaption" rows="4" class="w-100" hide-details="auto" />
             </div>
-            <div class="flex flex-column gap-2">
-              <label class="font-medium">标签（逗号分隔）</label>
-              <InputText v-model="editTagsText" class="w-full" />
-              <div v-if="parseTags(editTagsText).length" class="flex flex-wrap gap-2">
-                <Chip v-for="tag in parseTags(editTagsText)" :key="tag" :label="tag" />
+            <div class="d-flex flex-column ga-2">
+              <label class="font-weight-medium">标签（逗号分隔）</label>
+              <VTextField v-model="editTagsText" class="w-100" hide-details="auto" />
+              <div v-if="parseTags(editTagsText).length" class="d-flex flex-wrap ga-2">
+                <VChip v-for="tag in parseTags(editTagsText)" :key="tag" size="small">{{ tag }}</VChip>
               </div>
             </div>
-            <div class="flex justify-content-between gap-3 align-items-center">
-              <span class="font-medium">过滤等级（0-10）</span>
-              <InputNumber v-model="editSanityLevel" :min="0" :max="10" :useGrouping="false" />
+            <div class="d-flex justify-space-between ga-3 align-center">
+              <span class="font-weight-medium">过滤等级（0-10）</span>
+              <VNumberInput v-model="editSanityLevel" :min="0" :max="10" hide-details="auto" />
             </div>
-            <div class="flex justify-content-between gap-3 align-items-center">
-              <span class="font-medium">R18G</span>
-              <InputSwitch v-model="editR18g" />
+            <div class="d-flex justify-space-between ga-3 align-center">
+              <span class="font-weight-medium">R18G</span>
+              <VSwitch v-model="editR18g" color="primary" hide-details />
             </div>
-            <div class="flex justify-content-between gap-3 align-items-center">
-              <span class="font-medium">AI 作品</span>
-              <InputSwitch v-model="editIsAi" />
+            <div class="d-flex justify-space-between ga-3 align-center">
+              <span class="font-weight-medium">AI 作品</span>
+              <VSwitch v-model="editIsAi" color="primary" hide-details />
             </div>
           </div>
 
-          <Divider />
+          <VDivider />
 
-          <div class="flex justify-content-end gap-2">
-            <Button label="确认导入" icon="pi pi-download" :loading="importing" @click="onConfirmImport" />
+          <div class="d-flex justify-end ga-2">
+            <VBtn prepend-icon="mdi-download" :loading="importing" @click="onConfirmImport">确认导入</VBtn>
           </div>
         </div>
-      </template>
-    </Card>
+      </VCardText>
+    </VCard>
 
     <!-- 当前任务进度 -->
-    <Card v-if="activeTask && (activeTask.status === 'pending' || activeTask.status === 'running')" class="shadow-1">
-      <template #title>
-        <div class="flex align-items-center justify-content-between flex-wrap gap-2">
+    <VCard v-if="activeTask && (activeTask.status === 'pending' || activeTask.status === 'running')" class="elevation-1">
+      <VCardTitle>
+        <div class="d-flex align-center justify-space-between flex-wrap ga-2">
           <span>导入任务 #{{ activeTask.id }}：Pixiv {{ activeTask.pixiv_id }}</span>
-          <Tag :value="statusLabel(activeTask.status)" :severity="statusSeverity(activeTask.status)" />
+          <VChip size="small" :color="statusColor(activeTask.status)">{{ statusLabel(activeTask.status) }}</VChip>
         </div>
-      </template>
-      <template #content>
-        <div class="flex flex-column gap-2">
-          <ProgressBar :value="activeProgress" />
-          <span class="text-sm text-color-secondary">
+      </VCardTitle>
+      <VCardText>
+        <div class="d-flex flex-column ga-2">
+          <VProgressLinear :model-value="activeProgress" color="primary" />
+          <span class="text-body-2 text-medium-emphasis">
             {{ activeTask.status === 'pending' ? '排队等待执行…' : `正在处理第 ${activeTask.current_page ?? 0} / ${activeTask.total_pages ?? '-'} 页` }}
           </span>
         </div>
-      </template>
-    </Card>
+      </VCardText>
+    </VCard>
 
     <!-- 历史任务 -->
-    <Card class="shadow-1">
-      <template #title>
-        <div class="flex align-items-center justify-content-between">
+    <VCard class="elevation-1">
+      <VCardTitle>
+        <div class="d-flex align-center justify-space-between">
           <span>历史任务</span>
-          <Button label="刷新" icon="pi pi-refresh" outlined size="small" :loading="loadingTasks" @click="loadTasks" />
+          <VBtn prepend-icon="mdi-refresh" variant="outlined" size="small" :loading="loadingTasks" @click="loadTasks">刷新</VBtn>
         </div>
-      </template>
-      <template #content>
-        <DataTable :value="tasks" :loading="loadingTasks" striped-rows data-key="id" :rows="10" paginator paginator-template="FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink" :row-class="(row) => (selectedTask && selectedTask.id === row.id ? 'bg-primary-100' : '')" @row-click="({ data }) => selectTask(data)">
-          <template #empty>
-            <div class="p-4 text-center text-color-secondary">暂无导入历史。确认导入后任务会显示在这里。</div>
+      </VCardTitle>
+      <VCardText>
+        <VDataTable
+          :headers="headers"
+          :items="tasks"
+          :loading="loadingTasks"
+          item-value="id"
+          :items-per-page="10"
+          :row-props="taskRowProps"
+          class="rounded-lg"
+        >
+          <template #no-data>
+            <div class="p-4 text-center text-medium-emphasis">暂无导入历史。确认导入后任务会显示在这里。</div>
           </template>
-          <Column field="id" header="ID" :style="{ width: '4rem' }" />
-          <Column field="pixiv_id" header="Pixiv ID" :style="{ width: '7rem' }" />
-          <Column field="title" header="标题">
-            <template #body="{ data }">{{ data.title || '-' }}</template>
-          </Column>
-          <Column header="状态" :style="{ width: '6rem' }">
-            <template #body="{ data }">
-              <Tag :value="statusLabel(data.status)" :severity="statusSeverity(data.status)" />
-            </template>
-          </Column>
-          <Column header="进度" :style="{ width: '9rem' }">
-            <template #body="{ data }">
-              <span v-if="data.status === 'running' || data.status === 'pending'">
-                {{ data.current_page ?? 0 }} / {{ data.total_pages ?? '-' }}
-              </span>
-              <span v-else-if="data.status === 'success'">{{ data.total_pages ?? '-' }} 页</span>
-              <span v-else>-</span>
-            </template>
-          </Column>
-          <Column header="创建时间" :style="{ width: '12rem' }">
-            <template #body="{ data }">{{ formatTime(data.created_at) }}</template>
-          </Column>
-          <Column v-if="tasks.some((t) => t.error_message)" header="错误信息">
-            <template #body="{ data }">
-              <span v-if="data.error_message" class="text-red-500 text-sm">{{ data.error_message }}</span>
-            </template>
-          </Column>
-        </DataTable>
-      </template>
-    </Card>
+          <template #item.title="{ item }">{{ item.title || '-' }}</template>
+          <template #item.status="{ item }">
+            <VChip size="small" :color="statusColor(item.status)">{{ statusLabel(item.status) }}</VChip>
+          </template>
+          <template #item.progress="{ item }">
+            <span v-if="item.status === 'running' || item.status === 'pending'">
+              {{ item.current_page ?? 0 }} / {{ item.total_pages ?? '-' }}
+            </span>
+            <span v-else-if="item.status === 'success'">{{ item.total_pages ?? '-' }} 页</span>
+            <span v-else>-</span>
+          </template>
+          <template #item.created_at="{ item }">{{ formatTime(item.created_at) }}</template>
+          <template #item.error_message="{ item }">
+            <span v-if="item.error_message" class="text-body-2 text-error">{{ item.error_message }}</span>
+          </template>
+        </VDataTable>
+      </VCardText>
+    </VCard>
 
     <!-- 选中任务的结果 -->
-    <Card v-if="selectedTask && selectedTask.status === 'success' && selectedTask.result" class="shadow-1">
-      <template #title>
-        <div class="flex align-items-center gap-2">
-          <i class="pi pi-check-circle text-green-500"></i>
+    <VCard v-if="selectedTask && selectedTask.status === 'success' && selectedTask.result" class="elevation-1">
+      <VCardTitle>
+        <div class="d-flex align-center ga-2">
+          <VIcon icon="mdi-check-circle" color="success" />
           <span>导入结果：Pixiv {{ selectedTask.result.id }}（{{ selectedTask.result.created ? '新增' : '更新' }}）</span>
         </div>
-      </template>
-      <template #content>
-        <div v-if="!selectedTask.result.telegram_cache_enabled" class="mb-3 text-sm text-color-secondary">
+      </VCardTitle>
+      <VCardText>
+        <div v-if="!selectedTask.result.telegram_cache_enabled" class="mb-3 text-body-2 text-medium-emphasis">
           当前配置为导入阶段不缓存，首次发送时自动在 Telegram 缓存文件 ID。
         </div>
-        <div class="flex flex-column gap-2 text-sm">
-          <div v-for="page in selectedTask.result.pages" :key="page.index" class="flex flex-wrap gap-2 align-items-center">
-            <Tag value="存储" :severity="page.storage_url ? 'success' : 'danger'" />
-            <Tag value="PhotoID" :severity="page.compressed_file_id ? 'success' : 'warning'" />
-            <Tag value="DocumentID" :severity="page.original_file_id ? 'success' : 'warning'" />
+        <div class="d-flex flex-column ga-2 text-body-2">
+          <div v-for="page in selectedTask.result.pages" :key="page.index" class="d-flex flex-wrap ga-2 align-center">
+            <VChip size="small" :color="page.storage_url ? 'success' : 'error'">存储</VChip>
+            <VChip size="small" :color="page.compressed_file_id ? 'success' : 'warning'">PhotoID</VChip>
+            <VChip size="small" :color="page.original_file_id ? 'success' : 'warning'">DocumentID</VChip>
             <span>第 {{ page.index + 1 }} 页</span>
           </div>
         </div>
-      </template>
-    </Card>
+      </VCardText>
+    </VCard>
   </section>
 </template>

--- a/webui/src/views/PixivTokensView.vue
+++ b/webui/src/views/PixivTokensView.vue
@@ -1,18 +1,8 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
-import DataTable from 'primevue/datatable';
-import Column from 'primevue/column';
-import InputSwitch from 'primevue/toggleswitch';
-import Button from 'primevue/button';
-import Dialog from 'primevue/dialog';
-import InputText from 'primevue/inputtext';
-import ConfirmDialog from 'primevue/confirmdialog';
-import Skeleton from 'primevue/skeleton';
-import Tag from 'primevue/tag';
-import Toast from 'primevue/toast';
-import { useToast } from 'primevue/usetoast';
-import { useConfirm } from 'primevue/useconfirm';
+import { computed, onMounted, ref } from 'vue';
+import { useFeedback } from '@/composables/feedback';
 
+import type { DataTableHeader } from 'vuetify';
 import type { PixivTokenItem } from '@/services/api';
 import {
   listPixivTokens,
@@ -24,8 +14,7 @@ import {
   reloadPixivTokens
 } from '@/services/api';
 
-const toast = useToast();
-const confirm = useConfirm();
+const { toast, confirm } = useFeedback();
 
 const loading = ref(true);
 const saving = ref(false);
@@ -36,6 +25,21 @@ const editingId = ref<number | null>(null);
 const dialogToken = ref('');
 const dialogEnabled = ref(true);
 const showFull = ref<Record<number, boolean>>({});
+
+const dialogModel = computed({
+  get: () => dialogVisible.value,
+  set: (value: boolean) => {
+    dialogVisible.value = value;
+  },
+});
+
+const headers: DataTableHeader<PixivTokenItem>[] = [
+  { title: 'ID', key: 'id', sortable: false },
+  { title: 'Refresh Token', key: 'token', sortable: false },
+  { title: '状态', key: 'status', sortable: false },
+  { title: '启用', key: 'enabled', sortable: false },
+  { title: '操作', key: 'actions', sortable: false },
+];
 
 async function load() {
   loading.value = true;
@@ -67,7 +71,7 @@ function openEdit(item: PixivTokenItem) {
 async function save() {
   const token = dialogToken.value.trim();
   if (!token) {
-    toast.add({ severity: 'warn', summary: '无效输入', detail: 'Refresh Token 不能为空。', life: 3000 });
+    toast.add({ severity: 'warning', summary: '无效输入', detail: 'Refresh Token 不能为空。', life: 3000 });
     return;
   }
   saving.value = true;
@@ -116,7 +120,7 @@ function onDelete(item: PixivTokenItem) {
   confirm.require({
     message: `确定要删除第 ${item.id} 个 Pixiv Token 吗？`,
     header: '删除确认',
-    icon: 'pi pi-exclamation-triangle',
+    icon: 'mdi-alert-outline',
     acceptLabel: '删除',
     rejectLabel: '取消',
     accept: async () => {
@@ -147,91 +151,100 @@ onMounted(load);
 </script>
 
 <template>
-  <section class="flex flex-column gap-4">
-    <Toast />
-    <ConfirmDialog />
-    <header class="flex flex-column gap-2">
-      <h2 class="text-2xl font-semibold m-0">Pixiv Token 管理</h2>
-      <p class="text-color-secondary m-0">
+  <section class="d-flex flex-column ga-4">
+    <header class="d-flex flex-column ga-2">
+      <h2 class="text-h5 font-weight-bold ma-0">Pixiv Token 管理</h2>
+      <p class="text-medium-emphasis ma-0">
         可配置多个 Pixiv Refresh Token（轮询负载均衡）；修改后点击“重新加载”即可生效，无需重启后端。
       </p>
-      <div class="flex flex-wrap gap-2">
-        <Button label="刷新" icon="pi pi-refresh" outlined @click="load" :loading="loading" />
-        <Button label="添加" icon="pi pi-plus" @click="openCreate" />
-        <Button label="全部启用" icon="pi pi-check-square" severity="success" outlined @click="toggleAll(true)" :disabled="!items.length" />
-        <Button label="全部停用" icon="pi pi-ban" severity="warning" outlined @click="toggleAll(false)" :disabled="!items.length" />
-        <Button label="重新加载" icon="pi pi-refresh" @click="onReload" />
+      <div class="d-flex flex-wrap ga-2">
+        <VBtn prepend-icon="mdi-refresh" variant="outlined" @click="load" :loading="loading">刷新</VBtn>
+        <VBtn prepend-icon="mdi-plus" @click="openCreate">添加</VBtn>
+        <VBtn prepend-icon="mdi-checkbox-marked-outline" color="success" variant="outlined" @click="toggleAll(true)" :disabled="!items.length">全部启用</VBtn>
+        <VBtn prepend-icon="mdi-cancel" color="warning" variant="outlined" @click="toggleAll(false)" :disabled="!items.length">全部停用</VBtn>
+        <VBtn prepend-icon="mdi-refresh" @click="onReload">重新加载</VBtn>
       </div>
     </header>
 
-    <Skeleton v-if="loading" height="14rem" class="border-round" />
+    <VSkeletonLoader v-if="loading" height="14rem" class="rounded-lg" />
 
-    <DataTable v-else :value="items" :loading="loading" striped-rows class="shadow-1 border-round" :paginator="items.length > 10" :rows="10" paginator-template="FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink" data-key="id">
-      <template #empty>
-        <div class="p-4 text-center text-color-secondary">尚未配置 Pixiv Refresh Token，点击右上角“添加”开始配置。</div>
+    <VDataTable
+      v-else
+      :headers="headers"
+      :items="items"
+      :loading="loading"
+      item-value="id"
+      :items-per-page="10"
+      :hide-default-footer="items.length <= 10"
+      class="elevation-1 rounded-lg"
+    >
+      <template #no-data>
+        <div class="p-4 text-center text-medium-emphasis">尚未配置 Pixiv Refresh Token，点击右上角“添加”开始配置。</div>
       </template>
-      <Column field="id" header="ID" :style="{ width: '4rem' }" />
-      <Column header="Refresh Token">
-        <template #body="{ data }">
-          <div class="flex align-items-center gap-2">
-            <code class="text-sm bg-primary-50 px-2 py-1 border-round" style="word-break: break-all">
-              {{ showFull[data.id] ? data.token : data.masked }}
+      <template #item.token="{ item }">
+          <div class="d-flex align-center ga-2">
+            <code class="text-body-2 px-2 py-1 rounded-lg token-code" style="word-break: break-all">
+              {{ showFull[item.id] ? item.token : item.masked }}
             </code>
-            <Button
-              :icon="showFull[data.id] ? 'pi pi-eye-slash' : 'pi pi-eye'"
-              text
-              severity="secondary"
-              @click="showFull[data.id] = !showFull[data.id]"
+            <VBtn
+              :icon="showFull[item.id] ? 'mdi-eye-off' : 'mdi-eye'"
+              variant="text"
+              color="secondary"
+              :aria-label="showFull[item.id] ? '隐藏' : '显示'"
+              @click.stop="showFull[item.id] = !showFull[item.id]"
             />
           </div>
-        </template>
-      </Column>
-      <Column header="状态" :style="{ width: '6rem' }">
-        <template #body="{ data }">
-          <Tag :value="data.enabled ? '启用' : '停用'" :severity="data.enabled ? 'success' : 'warning'" />
-        </template>
-      </Column>
-      <Column header="启用" :style="{ width: '5rem' }">
-        <template #body="{ data }">
-          <InputSwitch :modelValue="data.enabled" @update:modelValue="(value) => toggleEnabled(data, value)" />
-        </template>
-      </Column>
-      <Column header="操作" :style="{ width: '9rem' }">
-        <template #body="{ data }">
-          <div class="flex gap-1">
-            <Button icon="pi pi-pencil" text severity="secondary" @click="openEdit(data)" />
-            <Button icon="pi pi-trash" text severity="danger" @click="onDelete(data)" />
+      </template>
+      <template #item.status="{ item }">
+          <div class="d-flex align-center justify-start w-100">
+            <VChip size="small" :color="item.enabled ? 'success' : 'warning'">{{ item.enabled ? '启用' : '停用' }}</VChip>
           </div>
-        </template>
-      </Column>
-    </DataTable>
+      </template>
+      <template #item.enabled="{ item }">
+          <div class="d-flex align-center justify-start w-100">
+            <VSwitch
+              :model-value="item.enabled"
+              color="primary"
+              hide-details
+              density="compact"
+              @update:modelValue="(value: boolean | null) => toggleEnabled(item, value ?? false)"
+            />
+          </div>
+      </template>
+      <template #item.actions="{ item }">
+          <div class="d-flex align-center justify-start w-100 ga-1">
+            <VBtn icon="mdi-pencil" variant="text" color="secondary" aria-label="修改" @click.stop="openEdit(item)" />
+            <VBtn icon="mdi-delete" variant="text" color="error" aria-label="删除" @click.stop="onDelete(item)" />
+          </div>
+      </template>
+    </VDataTable>
 
-    <Dialog
-      v-model:visible="dialogVisible"
-      :header="editingId === null ? '添加 Pixiv Token' : `修改 Pixiv Token #${editingId}`"
-      modal
-      :style="{ width: '30rem' }"
-    >
-      <div class="flex flex-column gap-4 p-2">
-        <div class="flex flex-column gap-2">
-          <label for="pixiv-token-input" class="font-medium">Refresh Token</label>
-          <InputText
+    <VDialog v-model="dialogModel" max-width="480" aria-labelledby="pixiv-token-dialog-title">
+      <VCard>
+        <VCardTitle id="pixiv-token-dialog-title">{{ editingId === null ? '添加 Pixiv Token' : `修改 Pixiv Token #${editingId}` }}</VCardTitle>
+        <VCardText>
+          <div class="d-flex flex-column ga-4">
+        <div class="d-flex flex-column ga-2">
+          <label for="pixiv-token-input" class="font-weight-medium">Refresh Token</label>
+          <VTextField
             id="pixiv-token-input"
             v-model="dialogToken"
             placeholder="从 Pixiv 申请到的 refresh_token"
             autocomplete="off"
-            class="w-full"
+            class="w-100"
           />
         </div>
-        <div class="flex justify-content-between gap-3 align-items-center">
-          <span class="font-medium">配置后立即启用</span>
-          <InputSwitch v-model="dialogEnabled" />
+        <div class="d-flex justify-space-between ga-3 align-center">
+          <span class="font-weight-medium">配置后立即启用</span>
+          <VSwitch v-model="dialogEnabled" color="primary" hide-details density="compact" />
         </div>
-        <div class="flex justify-content-end gap-2">
-          <Button label="取消" severity="secondary" outlined @click="dialogVisible = false" />
-          <Button label="保存" icon="pi pi-check" :loading="saving" @click="save" />
-        </div>
-      </div>
-    </Dialog>
+          </div>
+        </VCardText>
+        <VCardActions class="justify-end ga-2">
+          <VBtn color="secondary" variant="outlined" @click="dialogModel = false">取消</VBtn>
+          <VBtn prepend-icon="mdi-check" :loading="saving" @click="save">保存</VBtn>
+        </VCardActions>
+      </VCard>
+    </VDialog>
   </section>
 </template>

--- a/webui/src/views/PixivTokensView.vue
+++ b/webui/src/views/PixivTokensView.vue
@@ -5,7 +5,7 @@ import { useFeedback } from '@/composables/feedback';
 import type { DataTableHeader } from 'vuetify';
 import type { PixivTokenItem } from '@/services/api';
 import {
-  listPixivTokens,
+  listAllPixivTokens,
   addPixivToken,
   updatePixivToken,
   setPixivTokenEnabled,
@@ -44,8 +44,7 @@ const headers: DataTableHeader<PixivTokenItem>[] = [
 async function load() {
   loading.value = true;
   try {
-    const response = await listPixivTokens();
-    items.value = response.items;
+    items.value = await listAllPixivTokens();
   } catch (error) {
     console.error(error);
     toast.add({ severity: 'error', summary: '加载失败', detail: '无法获取 Pixiv Token 列表。', life: 4000 });

--- a/webui/src/views/PrivateChatsView.vue
+++ b/webui/src/views/PrivateChatsView.vue
@@ -1,14 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue';
-import DataTable from 'primevue/datatable';
-import Column from 'primevue/column';
-import InputText from 'primevue/inputtext';
-import Dropdown from 'primevue/select';
-import Button from 'primevue/button';
-import Tag from 'primevue/tag';
-import Toast from 'primevue/toast';
-import { useToast } from 'primevue/usetoast';
-import Skeleton from 'primevue/skeleton';
+import { useFeedback } from '@/composables/feedback';
+import type { DataTableHeader, DataTableSortItem } from 'vuetify';
 
 import PrivateUserDialog from '@/components/PrivateUserDialog.vue';
 import type {
@@ -25,20 +18,68 @@ import {
   listPrivateUsers,
   updatePrivateUser
 } from '@/services/api';
+import {
+  createServerTableRequestGuard,
+  toApiTableParams,
+  type ServerTableOptions,
+} from '@/utils/table-options';
 
-const toast = useToast();
+const { toast } = useFeedback();
 const loading = ref(true);
 const meta = ref<PrivateMeta | null>(null);
 const users = ref<PrivateUserListItem[]>([]);
 const detail = ref<PrivateUserDetail | null>(null);
 const dialogVisible = ref(false);
 
-const pagination = reactive({ page: 0, rows: 10, total: 0 });
+type NativeTableOptions = {
+  page: number;
+  itemsPerPage: number;
+  sortBy: ReadonlyArray<DataTableSortItem>;
+};
+
+const headers: DataTableHeader<PrivateUserListItem>[] = [
+  { title: '用户 ID', key: 'id', sortable: true },
+  { title: '昵称', key: 'nick_name', sortable: true },
+  { title: '聊天', key: 'enable_chat', sortable: false },
+  { title: '状态', key: 'status', sortable: false },
+  { title: '消息量', key: 'message_count', sortable: false },
+  { title: '最后活跃', key: 'last_activity', sortable: false },
+  { title: '操作', key: 'actions', sortable: false },
+];
+
+const pagination = reactive<ServerTableOptions & { total: number }>({
+  page: 1,
+  itemsPerPage: 10,
+  sortBy: [],
+  total: 0,
+});
 const filters = reactive<{ q: string; chatEnabled: boolean | null; status: string | null }>({
   q: '',
   chatEnabled: null,
   status: null
 });
+
+let tableReady = false;
+const requestGuard = createServerTableRequestGuard();
+
+function toServerTableOptions(options: NativeTableOptions): ServerTableOptions {
+  return {
+    page: options.page,
+    itemsPerPage: options.itemsPerPage,
+    sortBy: options.sortBy.map(({ key, order }) => ({
+      key,
+      ...(order === 'asc' || order === 'desc' ? { order } : {}),
+    })),
+  };
+}
+
+function optionsKey(options: ServerTableOptions): string {
+  return JSON.stringify({
+    page: options.page,
+    itemsPerPage: options.itemsPerPage,
+    sortBy: options.sortBy,
+  });
+}
 
 const statusOptions = computed(() => [
   { label: '全部状态', value: null },
@@ -51,36 +92,50 @@ async function ensureMeta() {
   }
 }
 
-async function loadUsers() {
+async function loadUsers(options: ServerTableOptions = pagination) {
+  const requestId = requestGuard.begin(optionsKey(options));
   loading.value = true;
   try {
+    const tableParams = toApiTableParams(options, ['id', 'nick_name']);
     const query: PrivateUserListQuery = {
       q: filters.q || undefined,
       chat_enabled: filters.chatEnabled === null ? undefined : filters.chatEnabled,
       status: filters.status || undefined,
-      limit: pagination.rows,
-      offset: pagination.page * pagination.rows
+      ...tableParams,
     };
     const response: PrivateUserListResponse = await listPrivateUsers(query);
+    if (!requestGuard.isLatest(requestId)) return;
     users.value = response.items;
     pagination.total = response.total;
   } catch (error) {
+    if (!requestGuard.isLatest(requestId)) return;
+    requestGuard.invalidateFailed(requestId);
     console.error(error);
     toast.add({ severity: 'error', summary: '加载失败', detail: '无法获取私聊用户列表。', life: 4000 });
   } finally {
-    loading.value = false;
+    if (requestGuard.isLatest(requestId)) {
+      loading.value = false;
+    }
   }
 }
 
 function onSearch() {
-  pagination.page = 0;
-  loadUsers();
+  const options = { ...pagination, page: 1 };
+  pagination.page = 1;
+  void loadUsers(options);
 }
 
-function onPage(event: { page: number; rows: number }) {
-  pagination.page = event.page;
-  pagination.rows = event.rows;
-  loadUsers();
+function onTableOptions(nativeOptions: NativeTableOptions) {
+  if (!tableReady) return;
+
+  const options = toServerTableOptions(nativeOptions);
+  const key = optionsKey(options);
+  if (!requestGuard.shouldLoad(key)) return;
+
+  pagination.page = options.page;
+  pagination.itemsPerPage = options.itemsPerPage;
+  pagination.sortBy = options.sortBy;
+  void loadUsers(options);
 }
 
 async function openDetail(userId: number) {
@@ -100,6 +155,7 @@ async function handleUpdate(payload: PrivateUserUpdatePayload) {
     const updated = await updatePrivateUser(detail.value.id, payload);
     detail.value = updated;
     users.value = users.value.map((user) => (user.id === updated.id ? updated : user));
+    dialogVisible.value = false;
     toast.add({ severity: 'success', summary: '保存成功', detail: '用户设置已更新。', life: 2500 });
     await loadUsers();
   } catch (error) {
@@ -109,108 +165,103 @@ async function handleUpdate(payload: PrivateUserUpdatePayload) {
 }
 
 onMounted(async () => {
-  await ensureMeta();
-  await loadUsers();
+  try {
+    await ensureMeta();
+  } catch (error) {
+    console.error(error);
+    toast.add({
+      severity: 'error',
+      summary: '加载失败',
+      detail: '无法获取私聊元数据。',
+      life: 4000,
+    });
+  }
+  tableReady = true;
+  await loadUsers(pagination);
 });
 </script>
 
 <template>
-  <section class="flex flex-column gap-4">
-    <Toast />
-    <header class="flex flex-column gap-2">
-      <h2 class="text-2xl font-semibold m-0">私聊管理</h2>
-      <p class="text-color-secondary m-0">
+  <section class="d-flex flex-column ga-4">
+    <header class="d-flex flex-column ga-2">
+      <h2 class="text-h5 font-weight-bold ma-0">私聊管理</h2>
+      <p class="text-medium-emphasis ma-0">
         管理私聊用户的权限，追踪消息互动情况。
       </p>
-      <div class="grid align-items-end gap-3">
-        <div class="col-12 md:col-4">
-          <label class="block text-sm text-color-secondary mb-2">搜索用户 ID / 昵称</label>
-          <span class="p-input-icon-left w-full">
-            <i class="pi pi-search" />
-            <InputText v-model="filters.q" placeholder="输入关键字" class="w-full" @keydown.enter="onSearch" />
-          </span>
-        </div>
-        <div class="col-6 md:col-3">
-          <label class="block text-sm text-color-secondary mb-2">聊天状态</label>
-          <Dropdown
+      <VRow class="align-end ga-3">
+        <VCol cols="12" md="4">
+          <VTextField id="private-search" label="搜索用户 ID / 昵称" v-model="filters.q" placeholder="输入关键字" prepend-inner-icon="mdi-magnify" class="w-100" @keydown.enter="onSearch" />
+        </VCol>
+        <VCol cols="6" md="3">
+          <VSelect
+            id="private-chat-enabled"
+            label="聊天状态"
             v-model="filters.chatEnabled"
-            :options="[
+            :items="[
               { label: '全部', value: null },
               { label: '可聊天', value: true },
-              { label: '已禁用', value: false }
+              { label: '已禁用', value: false },
             ]"
-            optionLabel="label"
-            optionValue="value"
-            class="w-full"
-            @change="onSearch"
+            item-title="label"
+            item-value="value"
+            class="w-100"
+            @update:modelValue="onSearch"
           />
-        </div>
-        <div class="col-6 md:col-3">
-          <label class="block text-sm text-color-secondary mb-2">用户状态</label>
-          <Dropdown
+        </VCol>
+        <VCol cols="6" md="3">
+          <VSelect
+            id="private-status"
+            label="用户状态"
             v-model="filters.status"
-            :options="statusOptions"
-            optionLabel="label"
-            optionValue="value"
-            class="w-full"
-            @change="onSearch"
+            :items="statusOptions"
+            item-title="label"
+            item-value="value"
+            class="w-100"
+            @update:modelValue="onSearch"
           />
-        </div>
-        <div class="col-12 md:col-2 flex md:justify-content-end">
-          <Button label="查询" icon="pi pi-filter" @click="onSearch" />
-        </div>
-      </div>
+        </VCol>
+        <VCol cols="12" md="2" class="d-flex justify-md-end">
+          <VBtn prepend-icon="mdi-filter-variant" @click="onSearch">查询</VBtn>
+        </VCol>
+      </VRow>
     </header>
 
-    <DataTable
-      :value="users"
+    <VDataTableServer
+      :headers="headers"
+      :items="users"
       :loading="loading"
-      dataKey="id"
-      responsiveLayout="scroll"
-      :rows="pagination.rows"
-      :first="pagination.page * pagination.rows"
-      :totalRecords="pagination.total"
-      paginator
-      lazy
-      :rowsPerPageOptions="[10, 20, 50]"
-      @page="onPage"
-      class="shadow-1 border-round-xl"
+      item-value="id"
+      :page="pagination.page"
+      :items-length="pagination.total"
+      :items-per-page="pagination.itemsPerPage"
+      :items-per-page-options="[10, 20, 50]"
+      :sort-by="pagination.sortBy"
+      @update:options="onTableOptions"
+      class="elevation-1 rounded-lg"
       v-if="users.length || !loading"
     >
-      <Column field="id" header="用户 ID" sortable />
-      <Column field="nick_name" header="昵称" sortable />
-      <Column header="聊天">
-        <template #body="{ data }">
-          <Tag :value="data.enable_chat ? '可用' : '禁用'" :severity="data.enable_chat ? 'success' : 'danger'" />
-        </template>
-      </Column>
-      <Column header="状态">
-        <template #body="{ data }">
-          <Tag :value="data.status" severity="info" />
-        </template>
-      </Column>
-      <Column header="消息量">
-        <template #body="{ data }">
-          <span class="font-medium">{{ data.message_count }}</span>
-        </template>
-      </Column>
-      <Column header="最后活跃">
-        <template #body="{ data }">
-          {{ data.last_activity ? new Date(data.last_activity).toLocaleString() : '暂无' }}
-        </template>
-      </Column>
-      <Column header="操作" style="width: 8rem">
-        <template #body="{ data }">
-          <Button label="详情" size="small" icon="pi pi-eye" @click="openDetail(data.id)" />
-        </template>
-      </Column>
-    </DataTable>
+      <template #item.enable_chat="{ item }">
+        <VChip :color="item.enable_chat ? 'success' : 'error'">{{ item.enable_chat ? '可用' : '禁用' }}</VChip>
+      </template>
+      <template #item.status="{ item }">
+        <VChip color="info">{{ item.status }}</VChip>
+      </template>
+      <template #item.message_count="{ item }">
+        <span class="font-weight-medium">{{ item.message_count }}</span>
+      </template>
+      <template #item.last_activity="{ item }">
+        {{ item.last_activity ? new Date(item.last_activity).toLocaleString() : '暂无' }}
+      </template>
+      <template #item.actions="{ item }">
+        <VBtn size="small" variant="text" color="primary" prepend-icon="mdi-eye" @click="openDetail(item.id)">详情</VBtn>
+      </template>
+    </VDataTableServer>
 
-    <div v-else class="grid">
-      <div class="col-12" v-for="index in 3" :key="index">
-        <Skeleton height="7rem" class="border-round" />
-      </div>
-    </div>
+    <VRow v-else>
+      <VCol cols="12" v-for="index in 3" :key="index">
+        <VSkeletonLoader height="7rem" class="rounded-lg" />
+      </VCol>
+    </VRow>
 
     <PrivateUserDialog
       v-model:visible="dialogVisible"

--- a/webui/tests/button-props.test.ts
+++ b/webui/tests/button-props.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+function sourceFiles(directory: URL): URL[] {
+  const files: URL[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const child = new URL(`${entry.name}${entry.isDirectory() ? '/' : ''}`, directory);
+    if (entry.isDirectory()) files.push(...sourceFiles(child));
+    else if (/\.(?:vue|ts|js)$/.test(entry.name)) files.push(child);
+  }
+  return files;
+}
+
+const files = sourceFiles(new URL('../src/', import.meta.url));
+const sources = files.map((file) => [file.pathname, readFileSync(file, 'utf8')] as const);
+const allSource = sources.map(([, content]) => content).join('\n');
+
+test('WebUI has no compatibility layer or legacy component contracts', () => {
+  for (const path of [
+    '../src/components/ui.ts',
+    '../src/components/ui.js',
+    '../src/components/button-props.ts',
+    '../src/components/button-props.js',
+    '../src/composables/feedback.js',
+    '../src/services/api.js',
+    '../src/router/index.js',
+    '../src/main.js',
+  ]) {
+    assert.equal(existsSync(new URL(path, import.meta.url)), false, path);
+  }
+
+  for (const [name, source] of sources) {
+    assert.doesNotMatch(source, /@\/components\/ui/, name);
+    assert.doesNotMatch(source, /from ['"]vuetify\/components['"]/, name);
+    assert.doesNotMatch(source, /from ['"]primevue\//, name);
+    assert.doesNotMatch(source, /<(?:Ui[A-Z][A-Za-z0-9_]*|Button|Tag|Input(?:Text|Number|Switch)?|Dropdown|Chips|Dialog|DataTable|Column)\b/, name);
+    assert.doesNotMatch(source, /<i\b[^>]*\bmdi\b/i, name);
+    if (name.endsWith('.vue')) {
+      assert.doesNotMatch(source, /\bseverity\s*=/, name);
+      assert.doesNotMatch(source, /\b(?:useGrouping|data-key)\s*=/, name);
+      assert.doesNotMatch(source, /<(?:VChip|v-chip)\b[^>]*\bvalue\s*=/s, name);
+      assert.doesNotMatch(source, /<(?:Ui[A-Z][A-Za-z0-9_]*|Button|Tag|Input[A-Za-z0-9_]*|Dropdown|Chips|Dialog|DataTable|Column)\b[^>]*\b(?:label|outlined|text|value|severity)\s*=/s, name);
+    }
+  }
+
+  assert.doesNotMatch(allSource, /<(?:VCard|v-card)(?![-A-Za-z0-9_])[^>]*\b(?:outlined|text)\b/);
+  assert.doesNotMatch(allSource, /<(?:VBtn|v-btn)[^>]*\b(?:outlined|text)\s*=/);
+});
+
+test('shared UI uses native Vuetify components', () => {
+  assert.match(allSource, /<(?:VCard|v-card)\b/);
+  assert.match(allSource, /<(?:VSwitch|v-switch)\b/);
+  assert.match(allSource, /<(?:VBtn|v-btn)\b/);
+  assert.match(allSource, /<VDataTable(?:Server)?\b/);
+  assert.doesNotMatch(allSource, /\bUi(?:Card|InputSwitch|Button|DataTable)\b/);
+});
+
+test('icon-only native buttons are labelled and icons use the icon prop', () => {
+  const buttonTags = allSource.match(/<(?:VBtn|v-btn)\b[\s\S]*?(?:\/>|>)/g) ?? [];
+  assert.ok(buttonTags.length > 0);
+
+  for (const tag of buttonTags) {
+    if (/(?:^|\s):?icon\s*=/.test(tag)) {
+      assert.match(tag, /(?:^|\s):?aria-label\s*=/, tag);
+    }
+    assert.doesNotMatch(tag, /(?:^|\s)(?:label|outlined|text)\s*=/, tag);
+  }
+
+  const iconTags = allSource.match(/<(?:VIcon|v-icon)\b[\s\S]*?(?:\/>|>)/g) ?? [];
+  assert.ok(iconTags.length > 0);
+  for (const tag of iconTags) {
+    assert.match(tag, /(?:^|\s):?icon\s*=/, tag);
+  }
+});

--- a/webui/tests/card-radius.test.ts
+++ b/webui/tests/card-radius.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+function vueFiles(directory: URL): URL[] {
+  const files: URL[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const child = new URL(`${entry.name}${entry.isDirectory() ? '/' : ''}`, directory);
+    if (entry.isDirectory()) files.push(...vueFiles(child));
+    else if (entry.name.endsWith('.vue')) files.push(child);
+  }
+  return files;
+}
+
+test('native cards use the shared large radius without compatibility adapters', () => {
+  const statCardSource = readFileSync(new URL('../src/components/StatCard.vue', import.meta.url), 'utf8');
+  const allVue = vueFiles(new URL('../src/', import.meta.url))
+    .map((file) => readFileSync(file, 'utf8'))
+    .join('\n');
+
+  assert.match(statCardSource, /<v-card\b[^>]*\brounded-lg\b/);
+  assert.doesNotMatch(allVue, /rounded-xl/);
+  assert.doesNotMatch(allVue, /<UiCard\b/);
+});

--- a/webui/tests/input-switch-style.test.ts
+++ b/webui/tests/input-switch-style.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const pixivSource = readFileSync(new URL('../src/views/PixivTokensView.vue', import.meta.url), 'utf8');
+const botTokenSource = readFileSync(new URL('../src/views/BotTokensView.vue', import.meta.url), 'utf8');
+const styles = readFileSync(new URL('../src/styles/main.css', import.meta.url), 'utf8');
+
+test('native switches use primary color and compact density where table controls need it', () => {
+  assert.match(pixivSource, /<VSwitch\b[\s\S]*?color="primary"[\s\S]*?hide-details[\s\S]*?density="compact"/);
+  assert.match(botTokenSource, /<VSwitch\b[^>]*color="primary"[^>]*hide-details[^>]*density="compact"/);
+  assert.doesNotMatch(pixivSource, /<UiInputSwitch\b|<InputSwitch\b/);
+});
+
+test('switch styling relies on Vuetify props rather than flat-thumb overrides', () => {
+  assert.doesNotMatch(styles, /\.v-switch--flat\s+\.v-switch__thumb/);
+  assert.doesNotMatch(styles, /thumb-color|thumbColor/);
+});

--- a/webui/tests/legacy-layout-utilities.test.ts
+++ b/webui/tests/legacy-layout-utilities.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+function vueFiles(directory: URL): URL[] {
+  const files: URL[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const child = new URL(`${entry.name}${entry.isDirectory() ? '/' : ''}`, directory);
+    if (entry.isDirectory()) files.push(...vueFiles(child));
+    else if (entry.name.endsWith('.vue')) files.push(child);
+  }
+  return files;
+}
+
+test('Vue templates use Vuetify layout utilities without PrimeFlex or UI aliases', () => {
+  const styles = readFileSync(new URL('../src/styles/main.css', import.meta.url), 'utf8');
+  assert.doesNotMatch(styles, /\.flex\s*\{/);
+  assert.doesNotMatch(styles, /\.gap-[1-4]\s*\{/);
+  assert.doesNotMatch(styles, /\.(?:grid|col-\d+|field|border-round(?:-(?:lg|xl))?|text-color-secondary|surface-card)\s*\{/);
+
+  const legacyUtility = /(?:^|\s)(?:flex|gap-[1-4]|align-items-(?:start|center|end|baseline|stretch)|justify-content-(?:start|center|end|between|around|evenly)|grid|formgrid|p-fluid|field|col-\d+|(?:sm|md|lg|xl):(?:col-\d+|w-[^\s"]+)|p-inputtext|p-input-icon-left|w-full|h-full|[wh]-\d+rem|border-(?:circle|round(?:-(?:lg|xl))?)|shadow-[12]|font-(?:medium|semibold|bold)|text-(?:sm|base|lg|xl|2xl|3xl)|m-0|bg-primary-(?:50|100)|text-red-500|block)(?=\s|")/;
+  for (const file of vueFiles(new URL('../src/', import.meta.url))) {
+    const source = readFileSync(file, 'utf8');
+    assert.doesNotMatch(source, legacyUtility, file.pathname);
+    assert.doesNotMatch(source, /@\/components\/ui|<Ui[A-Z]|<Button\b|<Tag\b/, file.pathname);
+  }
+});

--- a/webui/tests/native-dialogs.test.ts
+++ b/webui/tests/native-dialogs.test.ts
@@ -1,0 +1,225 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import {
+  groupFormSnapshot,
+  normalizeAdminIds,
+  privateUserFormSnapshot,
+} from '../src/utils/dialog-form.ts';
+import type { GroupDetail, PrivateUserDetail } from '../src/services/api.ts';
+
+const groupDialog = readFileSync(
+  new URL('../src/components/GroupDetailDialog.vue', import.meta.url),
+  'utf8',
+);
+const privateDialog = readFileSync(
+  new URL('../src/components/PrivateUserDialog.vue', import.meta.url),
+  'utf8',
+);
+
+const dialogs = [
+  ['group detail dialog', groupDialog],
+  ['private user dialog', privateDialog],
+] as const;
+
+test('dialog form helpers create pure reset snapshots and normalize admin IDs', () => {
+  const group = {
+    id: 7,
+    name: 'Example group',
+    status: 'active',
+    enable: true,
+    enable_chat: false,
+    chat_mode: 'balanced',
+    sanity_limit: 12,
+    allow_r18g: true,
+    allow_setu: false,
+    admin_ids: [101, 202],
+    message_count: 4,
+    last_activity: null,
+    recent_messages: [],
+  } as GroupDetail;
+  const user = {
+    id: 9,
+    nick_name: 'Example user',
+    status: 'active',
+    enable_chat: true,
+    sanity_limit: 8,
+    allow_r18g: false,
+    message_count: 3,
+    last_activity: null,
+    recent_messages: [],
+  } as PrivateUserDetail;
+
+  const groupSnapshot = groupFormSnapshot(group);
+  assert.deepEqual(groupSnapshot, {
+    name: 'Example group',
+    enable: true,
+    enable_chat: false,
+    chat_mode: 'balanced',
+    sanity_limit: 12,
+    allow_r18g: true,
+    allow_setu: false,
+    admin_ids: [101, 202],
+  });
+  groupSnapshot.admin_ids?.push(303);
+  assert.deepEqual(group.admin_ids, [101, 202]);
+  assert.deepEqual(groupFormSnapshot(null), {});
+
+  assert.deepEqual(privateUserFormSnapshot(user), {
+    nick_name: 'Example user',
+    enable_chat: true,
+    sanity_limit: 8,
+    allow_r18g: false,
+    status: 'active',
+  });
+  assert.deepEqual(privateUserFormSnapshot(null), {});
+
+  assert.deepEqual(normalizeAdminIds([101, '202', 'invalid', 303]), [101, 202, 303]);
+  assert.deepEqual(
+    normalizeAdminIds(['12abc', '12.5', 12.5, Number.NaN, Number.POSITIVE_INFINITY, -7, '-8']),
+    [],
+  );
+  assert.deepEqual(normalizeAdminIds([0, '0']), [0, 0]);
+  assert.deepEqual(normalizeAdminIds(undefined), []);
+});
+
+test('dialogs use native Vuetify card sections and writable v-model bridges', () => {
+  for (const [name, source] of dialogs) {
+    assert.match(source, /<VDialog\s+v-model="dialogModel"/, name);
+    assert.match(source, /<VCard\b/, name);
+    assert.match(source, /<VCardTitle\b/, name);
+    assert.match(source, /<VCardText\b/, name);
+    assert.match(source, /<VCardActions\b/, name);
+    assert.match(source, /const dialogModel = computed\(\{/, name);
+    assert.match(source, /get: \(\) => props\.visible && Boolean\(props\.(?:group|user)\)/, name);
+    assert.match(source, /set: \(value\) => emit\('update:visible', value\)/, name);
+    assert.doesNotMatch(source, /:visible=|@update:visible=/, name);
+  }
+});
+
+test('dialogs preserve declared and called parent-facing emits', () => {
+  for (const [name, source] of dialogs) {
+    assert.match(source, /const emit = defineEmits<\{[\s\S]*\(e: 'update:visible', value: boolean\): void;[\s\S]*\(e: 'submit', value:/, name);
+    assert.match(source, /function close\(\) \{[\s\S]*emit\('update:visible', false\);[\s\S]*\}/, `${name} close wiring`);
+    assert.match(source, /function save\(\) \{[\s\S]*emit\('submit',/, `${name} save wiring`);
+    assert.match(source, /<VBtn[^>]*@click="close"[^>]*>取消<\/VBtn>/, `${name} cancel button`);
+    assert.match(source, /<VBtn[^>]*@click="save"[^>]*>保存<\/VBtn>/, `${name} save button`);
+  }
+});
+
+test('dialogs contain only native imports and timeline icon slots', () => {
+  for (const [name, source] of dialogs) {
+    assert.doesNotMatch(source, /from ['"]primevue\//, `${name} PrimeVue import`);
+    assert.doesNotMatch(source, /(?:from ['"]@\/components\/ui|\bUi[A-Z][A-Za-z0-9_]*)/, `${name} compatibility import`);
+    assert.match(source, /<VTimeline\b/, `${name} timeline`);
+    assert.match(source, /<template #icon>/, `${name} timeline icon slot`);
+    assert.match(source, /<VIcon\b/, `${name} native icon`);
+    assert.doesNotMatch(source, /<i\b/, `${name} raw icon element`);
+  }
+});
+
+test('dialogs use native Vuetify form controls and option props', () => {
+  assert.match(groupDialog, /<VTextField\b/, 'group text field');
+  assert.match(groupDialog, /<VNumberInput\b/, 'group number input');
+  assert.match(groupDialog, /<VSelect\b/, 'group select');
+  assert.match(groupDialog, /<VSwitch\b/, 'group switches');
+  assert.match(groupDialog, /<VCombobox\b/, 'group admin IDs');
+  assert.match(groupDialog, /:items="meta\?\.chat_modes \?\? \[\]"/, 'group select items');
+  assert.match(groupDialog, /item-title="label"/, 'group select titles');
+  assert.match(groupDialog, /item-value="value"/, 'group select values');
+  assert.match(groupDialog, /:delimiters="\[','\]"/, 'group combobox delimiters');
+
+  assert.match(privateDialog, /<VTextField\b/, 'private text field');
+  assert.match(privateDialog, /<VNumberInput\b/, 'private number input');
+  assert.match(privateDialog, /<VSelect\b/, 'private select');
+  assert.match(privateDialog, /<VSwitch\b/, 'private switches');
+  assert.match(privateDialog, /:items="meta\?\.statuses \?\? \[\]"/, 'private select items');
+  assert.match(privateDialog, /@update:modelValue=/, 'native update event');
+
+  for (const [name, source] of dialogs) {
+    assert.doesNotMatch(source, /@change\b/, name);
+    assert.doesNotMatch(source, /\b(?:severity|separator|useGrouping|modal|header|label|outlined|text)=/, name);
+    assert.doesNotMatch(source, /#(?:content|footer)\b/, name);
+  }
+});
+
+test('dialogs use native colors, variants, and button slots without compatibility imports', () => {
+  for (const [name, source] of dialogs) {
+    assert.doesNotMatch(source, /@\/components\/ui|from ['"]vuetify\/components['"]/, name);
+    assert.match(source, /color="info"/, `${name} info color`);
+    assert.match(source, /color="warning"/, `${name} warning color`);
+    assert.match(source, /variant="outlined"/, `${name} outlined variant`);
+    assert.match(source, /<VBtn[^>]*>\s*(?:取消|保存)/, `${name} button default slots`);
+  }
+});
+
+test('group status formerly using help severity uses native info color', () => {
+  assert.match(
+    groupDialog,
+    /<VChip[^>]*color="info"[^>]*>\s*状态 \{\{ group\.status \}\}<\/VChip>/,
+  );
+  assert.doesNotMatch(groupDialog, /severity="help"/);
+});
+
+test('dialogs repopulate forms when visible changes or the entity changes', () => {
+  assert.match(groupDialog, /function syncForm\(group: GroupDetail \| null\)/, 'group reset helper');
+  assert.match(
+    groupDialog,
+    /watch\(\s*\[\s*\(\) => props\.group,\s*\(\) => props\.visible\s*\],/s,
+    'group visible-driven watcher',
+  );
+  assert.match(groupDialog, /\(\[group\]\) => syncForm\(group\)/, 'group watcher callback');
+
+  assert.match(privateDialog, /function syncForm\(user: PrivateUserDetail \| null\)/, 'private reset helper');
+  assert.match(
+    privateDialog,
+    /watch\(\s*\[\s*\(\) => props\.user,\s*\(\) => props\.visible\s*\],/s,
+    'private visible-driven watcher',
+  );
+  assert.match(privateDialog, /\(\[user\]\) => syncForm\(user\)/, 'private watcher callback');
+});
+
+test('dialogs expose accessible names for every standalone form control', () => {
+  const controls = [
+    ['group-name', '群名称', 'VTextField'],
+    ['group-chat-mode', '聊天模式', 'VSelect'],
+    ['group-enable', '群启用', 'VSwitch'],
+    ['group-enable-chat', '允许聊天', 'VSwitch'],
+    ['group-allow-setu', '允许涩图', 'VSwitch'],
+    ['group-allow-r18g', '允许 R18G', 'VSwitch'],
+    ['group-sanity-limit', '理智值上限', 'VNumberInput'],
+    ['group-admin-ids', '管理员 ID 列表', 'VCombobox'],
+  ] as const;
+
+  for (const [id, label, component] of controls) {
+    assert.match(groupDialog, new RegExp(`<label[^>]*\\bfor="${id}"[^>]*>[^<]*${label}`), `group label ${id}`);
+    assert.match(groupDialog, new RegExp(`<${component}[^>]*\\bid="${id}"`), `group control ${id}`);
+  }
+
+  const privateControls = [
+    ['private-nick-name', '昵称', 'VTextField'],
+    ['private-status', '状态', 'VSelect'],
+    ['private-enable-chat', '允许聊天', 'VSwitch'],
+    ['private-allow-r18g', '允许 R18G', 'VSwitch'],
+    ['private-sanity-limit', '理智值上限', 'VNumberInput'],
+  ] as const;
+
+  for (const [id, label, component] of privateControls) {
+    assert.match(privateDialog, new RegExp(`<label[^>]*\\bfor="${id}"[^>]*>[^<]*${label}`), `private label ${id}`);
+    assert.match(privateDialog, new RegExp(`<${component}[^>]*\\bid="${id}"`), `private control ${id}`);
+  }
+});
+
+test('dialogs label their cards and preserve normalized submit payloads', () => {
+  assert.match(groupDialog, /<VDialog[^>]*aria-labelledby="group-dialog-title"/);
+  assert.match(groupDialog, /<VCardTitle id="group-dialog-title">群组详情<\/VCardTitle>/);
+  assert.match(privateDialog, /<VDialog[^>]*aria-labelledby="private-dialog-title"/);
+  assert.match(privateDialog, /<VCardTitle id="private-dialog-title">私聊用户详情<\/VCardTitle>/);
+
+  assert.match(
+    groupDialog,
+    /const adminIds = normalizeAdminIds\(form\.admin_ids\);[\s\S]*emit\('submit', \{ \.\.\.form, admin_ids: adminIds \}\)/,
+    'group payload normalization and submit',
+  );
+  assert.match(privateDialog, /function save\(\) \{[\s\S]*emit\('submit', \{ \.\.\.form \}\);/, 'private submit payload');
+});

--- a/webui/tests/native-local-tables.test.ts
+++ b/webui/tests/native-local-tables.test.ts
@@ -21,6 +21,7 @@ const views = Object.fromEntries(
     readFileSync(new URL(`../src/views/${file}`, import.meta.url), 'utf8'),
   ]),
 ) as Record<(typeof viewFiles)[number], string>;
+const apiSource = readFileSync(new URL('../src/services/api.ts', import.meta.url), 'utf8');
 
 test('task views use only native Vuetify imports and auto-imported templates', () => {
   for (const [name, source] of Object.entries(views)) {
@@ -71,6 +72,11 @@ test('local table pagination matches the token and import-task requirements', ()
   assert.match(pixiv, /:hide-default-footer="items\.length <= 10"/);
   assert.match(illustration, /:items-per-page="10"/);
   assert.doesNotMatch(illustration, /hide-default-footer/);
+});
+
+test('Pixiv local table loads all server pages before rendering', () => {
+  assert.match(apiSource, /export async function listAllPixivTokens/);
+  assert.match(views['PixivTokensView.vue'], /listAllPixivTokens/);
 });
 
 test('illustration task row props select the native item and return a mouse click handler', () => {

--- a/webui/tests/native-local-tables.test.ts
+++ b/webui/tests/native-local-tables.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import type { IllustrationImportTask } from '../src/services/api.ts';
+import {
+  createIllustrationTaskHeaders,
+  createIllustrationTaskRowProps,
+} from '../src/utils/illustration-task-table.ts';
+
+const viewFiles = [
+  'DashboardView.vue',
+  'FeatureConfigView.vue',
+  'BotTokensView.vue',
+  'PixivTokensView.vue',
+  'IllustrationImportView.vue',
+] as const;
+
+const views = Object.fromEntries(
+  viewFiles.map((file) => [
+    file,
+    readFileSync(new URL(`../src/views/${file}`, import.meta.url), 'utf8'),
+  ]),
+) as Record<(typeof viewFiles)[number], string>;
+
+test('task views use only native Vuetify imports and auto-imported templates', () => {
+  for (const [name, source] of Object.entries(views)) {
+    assert.doesNotMatch(source, /@\/components\/ui|from ['"]vuetify\/components['"]/, name);
+    assert.doesNotMatch(source, /from ['"]primevue\//, name);
+    assert.doesNotMatch(source, /<Ui[A-Z]|\bUi[A-Z][A-Za-z0-9_]*/, name);
+  }
+});
+
+test('dashboard and feature pages use native cards, buttons, chips, skeletons, and dividers', () => {
+  const source = `${views['DashboardView.vue']}\n${views['FeatureConfigView.vue']}`;
+
+  for (const component of ['VCard', 'VBtn', 'VChip', 'VSkeletonLoader', 'VDivider']) {
+    assert.match(source, new RegExp(`<${component}\\b`), component);
+  }
+  assert.match(source, /<VBtn[^>]*>刷新<\/VBtn>/, 'native refresh button slot');
+  assert.match(source, /<VChip[^>]*color="info"[^>]*>可配置<\/VChip>/, 'info chip');
+  assert.match(source, /<VChip[^>]*color="warning"[^>]*>规划中<\/VChip>/, 'warning chip');
+  assert.doesNotMatch(source, /<(?:Button|Tag|Chip)\b[^>]*(?:severity|label|outlined|text|value)=/, 'legacy aliases');
+});
+
+test('Pixiv and illustration task lists use typed native VDataTable headers and item slots', () => {
+  const pixiv = views['PixivTokensView.vue'];
+  const illustration = views['IllustrationImportView.vue'];
+
+  assert.match(pixiv, /const headers: DataTableHeader<PixivTokenItem>\[\] = \[/);
+  assert.match(illustration, /const headers = computed<DataTableHeader<IllustrationImportTask>\[\]>\(\(\) => createIllustrationTaskHeaders\(tasks\.value\)\)/);
+
+  for (const [name, source] of [
+    ['PixivTokensView.vue', pixiv],
+    ['IllustrationImportView.vue', illustration],
+  ] as const) {
+    assert.match(source, /<VDataTable\b/, name);
+    assert.match(source, /:headers="headers"/, name);
+    assert.match(source, /item-value="id"/, name);
+    assert.match(source, /#item\.[A-Za-z_]+/, name);
+    assert.match(source, /#no-data/, name);
+    assert.match(source, /:loading="loading/, name);
+    assert.doesNotMatch(source, /<DataTable(?!Header)|<Column|data-key=|#body\b|\{\s*data\s*\}/, name);
+  }
+});
+
+test('local table pagination matches the token and import-task requirements', () => {
+  const pixiv = views['PixivTokensView.vue'];
+  const illustration = views['IllustrationImportView.vue'];
+
+  assert.match(pixiv, /:items-per-page="10"/);
+  assert.match(pixiv, /:hide-default-footer="items\.length <= 10"/);
+  assert.match(illustration, /:items-per-page="10"/);
+  assert.doesNotMatch(illustration, /hide-default-footer/);
+});
+
+test('illustration task row props select the native item and return a mouse click handler', () => {
+  const source = views['IllustrationImportView.vue'];
+
+  assert.match(source, /function taskRowProps\(\{ item \}: \{ item: IllustrationImportTask \}\)/);
+  assert.match(source, /return createIllustrationTaskRowProps\(item, selectedTask\.value\?\.id \?\? null, selectTask\);/);
+  assert.match(source, /:row-props="taskRowProps"/);
+  assert.doesNotMatch(source, /\{\s*data:\s*IllustrationImportTask\s*\}/);
+});
+
+test('illustration task headers retain the conditional error column', () => {
+  const task = { id: 4, error_message: '' } as IllustrationImportTask;
+  const failedTask = { id: 5, error_message: 'download failed' } as IllustrationImportTask;
+
+  assert.deepEqual(
+    createIllustrationTaskHeaders([task]).map((header) => header.key),
+    ['id', 'pixiv_id', 'title', 'status', 'progress', 'created_at'],
+  );
+  assert.deepEqual(
+    createIllustrationTaskHeaders([task, failedTask]).map((header) => header.key),
+    ['id', 'pixiv_id', 'title', 'status', 'progress', 'created_at', 'error_message'],
+  );
+});
+
+test('illustration task row helper exposes selected class and native click callback', () => {
+  const task = { id: 12 } as IllustrationImportTask;
+  const otherTask = { id: 13 } as IllustrationImportTask;
+  const selectedItems: IllustrationImportTask[] = [];
+  const onSelect = (item: IllustrationImportTask) => selectedItems.push(item);
+
+  const selected = createIllustrationTaskRowProps(task, 12, onSelect);
+  const unselected = createIllustrationTaskRowProps(otherTask, 12, onSelect);
+
+  assert.equal(selected.class, 'selected-task-row');
+  assert.equal(unselected.class, '');
+  selected.onClick({ type: 'click' } as MouseEvent);
+  assert.deepEqual(selectedItems, [task]);
+});
+
+test('local table action cells stop propagation and preserve awaited success-only dialog close checks', () => {
+  const pixiv = views['PixivTokensView.vue'];
+  assert.match(pixiv, /#item\.actions/);
+  assert.match(pixiv, /@click\.stop="openEdit\(item\)"/);
+  assert.match(pixiv, /@click\.stop="onDelete\(item\)"/);
+
+  for (const source of [views['BotTokensView.vue'], pixiv]) {
+    const save = source.match(/async function save\([\s\S]*?\n}\r?\n\r?\n(?:async function|function|onMounted)/)?.[0];
+    assert.ok(save);
+    assert.match(save, /await [A-Za-z]+(?:PixivToken|BotToken)[\s\S]*dialogVisible\.value = false;/);
+    assert.doesNotMatch(save, /catch[\s\S]*dialogVisible\.value = false;/);
+  }
+});
+
+test('token and import forms use native controls, dialog cards, and update:modelValue events', () => {
+  const source = [views['BotTokensView.vue'], views['PixivTokensView.vue'], views['IllustrationImportView.vue']].join('\n');
+
+  for (const component of ['VDialog', 'VCardTitle', 'VCardText', 'VCardActions', 'VTextField', 'VSwitch', 'VNumberInput', 'VTextarea', 'VChip']) {
+    assert.match(source, new RegExp(`<${component}\\b`), component);
+  }
+  assert.match(source, /const dialogModel = computed\(\{/);
+  assert.match(source, /<VDialog\s+v-model="dialogModel"/);
+  assert.match(source, /@update:modelValue=/);
+  assert.match(source, /<VProgressLinear[^>]*:model-value="activeProgress"/);
+  assert.doesNotMatch(source, /useGrouping|<(?:Button|Tag|Chip)\b[^>]*(?:severity|label|outlined|text|chip-value)=/);
+});
+
+test('native colors normalize danger, warn, and help aliases', () => {
+  const source = Object.values(views).join('\n');
+
+  assert.doesNotMatch(source, /(?:severity|color)=['"](?:danger|warn|help)['"]/);
+  assert.doesNotMatch(source, /statusSeverity/);
+  assert.match(source, /color="error"|:color="[^\n]*(?:error)/);
+  assert.match(source, /color="warning"|:color="[^\n]*(?:warning)/);
+  assert.match(source, /color="info"|:color="[^\n]*(?:info)/);
+});
+
+test('submit dialogs close only after awaited API success', () => {
+  for (const [name, source] of Object.entries({
+    'BotTokensView.vue': views['BotTokensView.vue'],
+    'PixivTokensView.vue': views['PixivTokensView.vue'],
+  })) {
+    const save = source.match(/async function save\([\s\S]*?\n}\r?\n\r?\n(?:async function|function|onMounted)/)?.[0];
+    assert.ok(save, `${name} save handler`);
+    assert.match(save, /try \{[\s\S]*?await [A-Za-z]+(?:PixivToken|BotToken)[\s\S]*?dialogVisible\.value = false;[\s\S]*?\} catch/, name);
+    assert.doesNotMatch(save, /catch[\s\S]*dialogVisible\.value = false;/, name);
+  }
+});

--- a/webui/tests/native-server-tables.test.ts
+++ b/webui/tests/native-server-tables.test.ts
@@ -1,0 +1,260 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { parseCommandHistoryUserId } from '../src/utils/command-history.ts';
+import {
+  createServerTableRequestGuard,
+  toApiTableParams,
+} from '../src/utils/table-options.ts';
+
+const viewFiles = [
+  'GroupsView.vue',
+  'PrivateChatsView.vue',
+  'CommandHistoryView.vue',
+] as const;
+
+const views = Object.fromEntries(
+  viewFiles.map((file) => [
+    file,
+    readFileSync(new URL(`../src/views/${file}`, import.meta.url), 'utf8'),
+  ]),
+) as Record<(typeof viewFiles)[number], string>;
+
+test('converts supported server-table sorting into API pagination parameters', () => {
+  assert.deepEqual(
+    toApiTableParams(
+      { page: 2, itemsPerPage: 20, sortBy: [{ key: 'name', order: 'asc' }] },
+      ['id', 'name'],
+    ),
+    { page: 2, page_size: 20, sort_by: 'name', sort_order: 'asc' },
+  );
+  assert.deepEqual(
+    toApiTableParams(
+      { page: 3, itemsPerPage: 50, sortBy: [{ key: 'id', order: 'desc' }] },
+      ['id', 'name'],
+    ),
+    { page: 3, page_size: 50, sort_by: 'id', sort_order: 'desc' },
+  );
+});
+
+test('omits unsupported, invalid, and absent server-table sorting', () => {
+  const base = { page: 1, page_size: 10 };
+  assert.deepEqual(
+    toApiTableParams(
+      { page: 1, itemsPerPage: 10, sortBy: [{ key: 'status', order: 'asc' }] },
+      ['id', 'name'],
+    ),
+    base,
+  );
+  assert.deepEqual(
+    toApiTableParams(
+      { page: 1, itemsPerPage: 10, sortBy: [{ key: 'id', order: 'invalid' as never }] },
+      ['id', 'name'],
+    ),
+    base,
+  );
+  assert.deepEqual(
+    toApiTableParams({ page: 1, itemsPerPage: 10, sortBy: [] }, ['id', 'name']),
+    base,
+  );
+});
+
+test('server-table request guard handles concurrency and retry invalidation', () => {
+  const guard = createServerTableRequestGuard();
+
+  assert.equal(guard.shouldLoad('page-a'), true);
+  const firstRequest = guard.begin('page-a');
+  assert.equal(guard.shouldLoad('page-a'), false);
+
+  const newerRequest = guard.begin('page-b');
+  assert.equal(guard.isLatest(firstRequest), false);
+  assert.equal(guard.isLatest(newerRequest), true);
+
+  guard.invalidateFailed(firstRequest);
+  assert.equal(guard.shouldLoad('page-b'), false);
+
+  guard.invalidateFailed(newerRequest);
+  assert.equal(guard.shouldLoad('page-b'), true);
+
+  const retryRequest = guard.begin('page-b');
+  assert.equal(guard.isLatest(retryRequest), true);
+  assert.equal(guard.shouldLoad('page-b'), false);
+  guard.invalidateFailed(retryRequest);
+  assert.equal(guard.shouldLoad('page-b'), true);
+});
+
+test('server-table views use native Vuetify components and options wiring', () => {
+  for (const [name, source] of Object.entries(views)) {
+    assert.match(source, /<VDataTableServer\b/, name);
+    assert.match(source, /:headers="headers"/, name);
+    assert.match(source, /item-value="id"/, name);
+    assert.match(source, /:items-length="pagination\.total"/, name);
+    assert.match(source, /:items-per-page="pagination\.itemsPerPage"/, name);
+    assert.match(source, /:page="pagination\.page"/, name);
+    assert.match(source, /:loading="loading"/, name);
+    assert.match(source, /@update:options="onTableOptions"/, name);
+    assert.match(source, /#item\.[A-Za-z_]+/, name);
+    assert.doesNotMatch(source, /@page\b|\bdataKey\b|\bdata-key\b/, name);
+    assert.doesNotMatch(
+      source,
+      /from ['"]primevue\/|from ['"]@\/components\/ui|<Ui[A-Z]|\bUi[A-Z][A-Za-z0-9_]*/,
+      name,
+    );
+    assert.match(source, /<VTextField\b/, `${name} text field`);
+    assert.match(source, /<VSelect\b/, `${name} select`);
+    assert.match(source, /<VBtn\b[^>]*>[^<]+<\/VBtn>/, `${name} button slot`);
+    assert.match(source, /<VChip\b/, `${name} chip`);
+    assert.match(source, /<VSkeletonLoader\b/, `${name} loading skeleton`);
+    assert.match(source, /@update:modelValue=/, `${name} native select event`);
+    assert.doesNotMatch(source, /\b(?:severity|optionLabel|optionValue|rowsPerPageOptions|totalRecords)=/, name);
+  }
+});
+
+test('server-table pagination defaults and sortable-key whitelists remain explicit', () => {
+  assert.match(views['GroupsView.vue'], /page: 1,\s*itemsPerPage: 10/);
+  assert.match(views['GroupsView.vue'], /\[10, 20, 50\]/);
+  assert.match(views['GroupsView.vue'], /\['id', 'name'\]/);
+
+  assert.match(views['PrivateChatsView.vue'], /page: 1,\s*itemsPerPage: 10/);
+  assert.match(views['PrivateChatsView.vue'], /\[10, 20, 50\]/);
+  assert.match(views['PrivateChatsView.vue'], /\['id', 'nick_name'\]/);
+
+  assert.match(views['CommandHistoryView.vue'], /page: 1,\s*itemsPerPage: 20/);
+  assert.match(views['CommandHistoryView.vue'], /\[20, 50, 100\]/);
+  assert.match(views['CommandHistoryView.vue'], /\['command', 'triggered_at'\]/);
+});
+
+test('server-table headers disable sorting for unsupported backend fields', () => {
+  const nonSortableHeaders = {
+    'GroupsView.vue': ['enable', 'enable_chat', 'message_count', 'last_activity', 'actions'],
+    'PrivateChatsView.vue': ['enable_chat', 'status', 'message_count', 'last_activity', 'actions'],
+    'CommandHistoryView.vue': ['arguments', 'user_id', 'chat_id', 'success', 'duration_ms', 'error_message'],
+  } as const;
+
+  for (const name of viewFiles) {
+    for (const key of nonSortableHeaders[name]) {
+      assert.match(views[name], new RegExp(`key: '${key}', sortable: false`), `${name} ${key}`);
+    }
+  }
+});
+
+test('legacy chip colors are mapped to native Vuetify colors', () => {
+  const allViews = Object.values(views).join('\n');
+  assert.match(allViews, /<VChip[^>]*:color="[^\"]*'error'/);
+  assert.match(allViews, /<VChip[^>]*:color="[^\"]*'warning'/);
+  assert.match(allViews, /color="info"/);
+  assert.doesNotMatch(allViews, /severity=|color="danger"|color="warn"|color="help"/);
+});
+
+test('detail dialogs close only after their awaited update succeeds', () => {
+  const updateHandlers = {
+    'GroupsView.vue': 'updateGroup',
+    'PrivateChatsView.vue': 'updatePrivateUser',
+  } as const;
+
+  for (const name of ['GroupsView.vue', 'PrivateChatsView.vue'] as const) {
+    const updateFunction = updateHandlers[name];
+    const handler = views[name].match(/async function handleUpdate[\s\S]*?\n}\r?\n\r?\nonMounted/)?.[0];
+    assert.ok(handler, `${name} handler`);
+    assert.match(
+      handler,
+      new RegExp(`try \\{[\\s\\S]*?const updated = await ${updateFunction}\\([\\s\\S]*?dialogVisible\\.value = false;[\\s\\S]*?\\} catch`),
+      `${name} success close`,
+    );
+    assert.doesNotMatch(handler, /catch[\s\S]*dialogVisible\.value = false;/, `${name} failure close`);
+  }
+});
+
+test('duplicate-request guards compare only native table options', () => {
+  for (const name of viewFiles) {
+    const source = views[name];
+    assert.match(source, /let tableReady = false;/, name);
+    assert.match(source, /if \(!tableReady\) return;/, name);
+    assert.match(source, /const requestGuard = createServerTableRequestGuard\(\);/, name);
+    assert.match(source, /const key = optionsKey\(options\);/, name);
+    assert.match(source, /if \(!requestGuard\.shouldLoad\(key\)\) return;/, name);
+    assert.doesNotMatch(source, /lastLoadedOptionsKey|requestSequence/, name);
+    assert.match(
+      source,
+      /return JSON\.stringify\(\{\s*page: options\.page,\s*itemsPerPage: options\.itemsPerPage,\s*sortBy: options\.sortBy,?\s*\}\);/s,
+      name,
+    );
+  }
+});
+
+test('groups and private users recover from metadata failures before loading rows', () => {
+  const metadataViews = {
+    'GroupsView.vue': 'loadGroups',
+    'PrivateChatsView.vue': 'loadUsers',
+  } as const;
+
+  for (const name of ['GroupsView.vue', 'PrivateChatsView.vue'] as const) {
+    const listFunction = metadataViews[name];
+    assert.match(
+      views[name],
+      new RegExp(
+        `onMounted\\(async \\(\\) => \\{[\\s\\S]*?try \\{[\\s\\S]*?await ensureMeta\\(\\);[\\s\\S]*?\\} catch \\(error\\)[\\s\\S]*?toast\\.add[\\s\\S]*?\\}[\\s\\S]*?tableReady = true;[\\s\\S]*?await ${listFunction}\\(pagination\\);`,
+      ),
+      name,
+    );
+  }
+});
+
+test('server-table loaders ignore stale responses and only latest requests clear loading', () => {
+  for (const name of viewFiles) {
+    const source = views[name];
+    assert.match(source, /const requestId = requestGuard\.begin\(optionsKey\(options\)\);/, name);
+    assert.match(source, /if \(!requestGuard\.isLatest\(requestId\)\) return;/, name);
+    assert.match(source, /requestGuard\.invalidateFailed\(requestId\);/, name);
+    assert.match(
+      source,
+      /finally \{[\s\S]*?if \(requestGuard\.isLatest\(requestId\)\) \{\s*loading\.value = false;\s*\}[\s\S]*?\}/,
+      name,
+    );
+  }
+});
+
+test('native controls own their labels through stable IDs', () => {
+  const controls = {
+    'GroupsView.vue': [
+      ['VTextField', 'groups-search', '搜索群 ID / 名称'],
+      ['VSelect', 'groups-enable', '启用状态'],
+      ['VSelect', 'groups-chat-enabled', '聊天功能'],
+    ],
+    'PrivateChatsView.vue': [
+      ['VTextField', 'private-search', '搜索用户 ID / 昵称'],
+      ['VSelect', 'private-chat-enabled', '聊天状态'],
+      ['VSelect', 'private-status', '用户状态'],
+    ],
+    'CommandHistoryView.vue': [
+      ['VTextField', 'command-history-command', '命令名称'],
+      ['VTextField', 'command-history-user-id', '用户 ID'],
+      ['VSelect', 'command-history-success', '执行状态'],
+    ],
+  } as const;
+
+  for (const name of viewFiles) {
+    const expectedControls = controls[name];
+    assert.doesNotMatch(views[name], /<label\b/, `${name} orphan label`);
+    for (const [component, id, label] of expectedControls) {
+      assert.match(
+        views[name],
+        new RegExp(`<${component}[^>]*\\bid="${id}"[^>]*\\blabel="${label}"`),
+        `${name} ${id}`,
+      );
+    }
+  }
+});
+
+test('command-history user ID parser accepts only safe non-negative integers', () => {
+  assert.equal(parseCommandHistoryUserId(''), undefined);
+  assert.equal(parseCommandHistoryUserId('  '), undefined);
+  assert.equal(parseCommandHistoryUserId('42'), 42);
+  assert.equal(parseCommandHistoryUserId('0007'), 7);
+  assert.equal(parseCommandHistoryUserId('1.5'), undefined);
+  assert.equal(parseCommandHistoryUserId('Infinity'), undefined);
+  assert.equal(parseCommandHistoryUserId('1e3'), undefined);
+  assert.equal(parseCommandHistoryUserId('-1'), undefined);
+  assert.equal(parseCommandHistoryUserId(String(Number.MAX_SAFE_INTEGER)), Number.MAX_SAFE_INTEGER);
+  assert.equal(parseCommandHistoryUserId('9007199254740992'), undefined);
+});

--- a/webui/tests/native-server-tables.test.ts
+++ b/webui/tests/native-server-tables.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 import { parseCommandHistoryUserId } from '../src/utils/command-history.ts';
 import {
+  collectAllPages,
   createServerTableRequestGuard,
   toApiTableParams,
 } from '../src/utils/table-options.ts';
@@ -19,6 +20,22 @@ const views = Object.fromEntries(
     readFileSync(new URL(`../src/views/${file}`, import.meta.url), 'utf8'),
   ]),
 ) as Record<(typeof viewFiles)[number], string>;
+
+test('collects every page before rendering a local table', async () => {
+  const requested: Array<[number, number]> = [];
+  const pages = [
+    { items: ['first'], pages: 2 },
+    { items: ['second'], pages: 2 },
+  ];
+
+  const items = await collectAllPages(async (page, pageSize) => {
+    requested.push([page, pageSize]);
+    return pages[page - 1];
+  }, 100);
+
+  assert.deepEqual(items, ['first', 'second']);
+  assert.deepEqual(requested, [[1, 100], [2, 100]]);
+});
 
 test('converts supported server-table sorting into API pagination parameters', () => {
   assert.deepEqual(

--- a/webui/tests/native-shared-components.test.ts
+++ b/webui/tests/native-shared-components.test.ts
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+function source(path: string): string {
+  return readFileSync(new URL(`../src/${path}`, import.meta.url), 'utf8');
+}
+
+const appSource = source('App.vue');
+const headerSource = source('components/AppHeader.vue');
+const sidebarSource = source('components/AppSidebar.vue');
+const timelineSource = source('components/ActivityTimeline.vue');
+const statCardSource = source('components/StatCard.vue');
+const feedbackSource = source('composables/feedback.ts');
+const stylesSource = source('styles/main.css');
+
+test('shared components use native Vuetify cards, chips, timeline items, icons, and no UI adapter imports', () => {
+  for (const [name, content] of Object.entries({
+    'AppHeader.vue': headerSource,
+    'AppSidebar.vue': sidebarSource,
+    'ActivityTimeline.vue': timelineSource,
+    'StatCard.vue': statCardSource
+  })) {
+    assert.doesNotMatch(content, /@\/components\/ui/, name);
+    assert.doesNotMatch(content, /\bUi[A-Z][A-Za-z0-9_]*/, name);
+    assert.doesNotMatch(content, /<i\b/, name);
+  }
+
+  assert.match(headerSource, /defineProps<\{\s*dark: boolean\s*\}>/);
+  assert.doesNotMatch(headerSource, /items|activePath/);
+  assert.match(headerSource, /<v-icon\b[^>]*icon="mdi-shield-star-outline"/);
+  assert.match(headerSource, /<v-btn\b[^>]*icon="mdi-theme-light-dark"/);
+  assert.match(timelineSource, /<v-timeline\b/);
+  assert.match(timelineSource, /<v-timeline-item\b/);
+  assert.match(timelineSource, /#opposite/);
+  assert.match(timelineSource, /#icon/);
+  assert.match(timelineSource, /#default/);
+  assert.match(timelineSource, /<v-icon\b[^>]*icon="mdi-flash"/);
+  assert.match(timelineSource, /<v-card\b/);
+  assert.match(timelineSource, /<v-card-title\b/);
+  assert.match(timelineSource, /<v-card-text\b/);
+  assert.match(timelineSource, /<v-chip\b[^>]*:color="[^"]*normalizeVuetifyColor/);
+  assert.match(statCardSource, /<v-card\b/);
+  assert.match(statCardSource, /<v-card-title\b/);
+  assert.match(statCardSource, /<v-card-text\b/);
+  assert.match(statCardSource, /<v-chip\b[^>]*:color="[^"]*normalizeVuetifyColor/);
+  assert.match(statCardSource, /<v-icon\b[^>]*:icon="icon"/);
+});
+
+test('sidebar delegates route navigation to VListItem and App does not push a second route', () => {
+  assert.match(sidebarSource, /<v-list-item[\s\S]*:to="item\.to"/);
+  assert.match(sidebarSource, /@click="emit\('navigate'\)"/);
+  assert.doesNotMatch(sidebarSource, /emit\('navigate',\s*item\.to/);
+  assert.doesNotMatch(appSource, /\brouter\.push\s*\(/);
+  assert.match(appSource, /@navigate="closeDrawer"/);
+});
+
+test('App starts open on desktop and closed on mobile while rendering an accessible confirmation dialog', () => {
+  assert.match(appSource, /const drawer = ref<boolean \| null>\(null\)/);
+  assert.match(appSource, /:permanent="mdAndUp"/);
+  assert.match(appSource, /:temporary="!mdAndUp"/);
+  assert.match(appSource, /const confirmationDialog = computed\(\{/);
+  assert.match(appSource, /<v-dialog\b[^>]*v-model="confirmationDialog"/);
+  assert.match(appSource, /<v-dialog\b[^>]*aria-labelledby="confirmation-title"[^>]*aria-describedby="confirmation-message"/);
+  assert.match(appSource, /<v-card-title\b[^>]*id="confirmation-title"/);
+  assert.match(appSource, /<v-card-text\b[^>]*id="confirmation-message"/);
+  assert.match(appSource, /confirmState\.icon/);
+  assert.match(appSource, /confirmState\.header/);
+  assert.match(appSource, /confirmState\.header\s*\|\|\s*'确认操作'/);
+  assert.match(appSource, /confirmState\.message/);
+  assert.match(appSource, /confirmState\.acceptLabel/);
+  assert.match(appSource, /confirmState\.rejectLabel/);
+  assert.match(appSource, /@click:outside="rejectConfirmation"/);
+  assert.match(appSource, /aria-label="关闭确认对话框"/);
+  assert.match(appSource, /rejectConfirmation\(\)/);
+  assert.match(appSource, /@click="acceptConfirmation"/);
+});
+
+test('navigation drawer button has a localized accessible label', () => {
+  assert.match(headerSource, /<v-app-bar-nav-icon\b[^>]*aria-label="打开导航菜单"/);
+});
+
+test('feedback normalizes legacy colors before the root snackbar consumes them', () => {
+  assert.match(feedbackSource, /export function normalizeVuetifyColor/);
+  assert.match(feedbackSource, /danger.*error/s);
+  assert.match(feedbackSource, /warn.*warning/s);
+  assert.match(feedbackSource, /help.*info/s);
+  assert.match(feedbackSource, /add\(payload:\s*\{\s*severity\?: string;/);
+  assert.match(feedbackSource, /feedbackState\.severity\s*=\s*normalizeVuetifyColor\(payload\.severity/);
+  assert.match(appSource, /<v-snackbar\b[^>]*:color="feedbackState\.severity"/);
+});
+
+test('feedback exposes reactive confirmation resolvers without blocking browser confirmation', async () => {
+  assert.match(feedbackSource, /export const confirmState = reactive/);
+  assert.match(feedbackSource, /export function acceptConfirmation/);
+  assert.match(feedbackSource, /export function rejectConfirmation/);
+  assert.match(feedbackSource, /export function closeConfirmation/);
+  assert.match(feedbackSource, /confirmState\.open\s*=\s*true/);
+  assert.match(feedbackSource, /close\(\)\s*\{[\s\S]*closeConfirmation\(\);/);
+  assert.doesNotMatch(feedbackSource, /window\.confirm/);
+
+  const feedback = await import('../src/composables/feedback.ts');
+  assert.equal(typeof feedback.confirmState, 'object');
+  assert.equal(typeof feedback.acceptConfirmation, 'function');
+  assert.equal(typeof feedback.rejectConfirmation, 'function');
+  assert.equal(typeof feedback.closeConfirmation, 'function');
+
+  const events: string[] = [];
+  const { confirm } = feedback.useFeedback();
+  confirm.require({
+    message: '确认继续？',
+    header: '测试确认',
+    acceptLabel: '继续',
+    rejectLabel: '返回',
+    accept: () => events.push('accept'),
+    reject: () => events.push('reject')
+  });
+  assert.equal(feedback.confirmState.open, true);
+  assert.equal(feedback.confirmState.header, '测试确认');
+  feedback.acceptConfirmation();
+  assert.deepEqual(events, ['accept']);
+  assert.equal(feedback.confirmState.open, false);
+
+  confirm.require({ message: '确认取消？', reject: () => events.push('reject') });
+  assert.equal(feedback.confirmState.header, '确认操作');
+  feedback.rejectConfirmation();
+  assert.deepEqual(events, ['accept', 'reject']);
+  assert.equal(feedback.confirmState.open, false);
+
+  confirm.require({ message: '仅关闭', reject: () => events.push('unexpected-reject') });
+  confirm.close();
+  assert.deepEqual(events, ['accept', 'reject']);
+  assert.equal(feedback.confirmState.open, false);
+  assert.equal(feedback.confirmState.accept, undefined);
+  assert.equal(feedback.confirmState.reject, undefined);
+
+  confirm.require({
+    message: '新对话框',
+    accept: () => events.push('new-accept'),
+    reject: () => events.push('new-reject')
+  });
+  feedback.rejectConfirmation();
+  assert.deepEqual(events, ['accept', 'reject', 'new-reject']);
+});
+
+test('Vuetify theme CSS uses color-mix and does not force a color scheme or rgba theme variables', () => {
+  assert.doesNotMatch(stylesSource, /color-scheme\s*:\s*light\s+dark/);
+  assert.doesNotMatch(stylesSource, /rgba\(var\(--v-theme-/);
+  assert.match(stylesSource, /color-mix\(in srgb, rgb\(var\(--v-theme-primary\)\) 20%, transparent\)/);
+  assert.match(stylesSource, /color-mix\(in srgb, rgb\(var\(--v-theme-primary\)\) 35%, transparent\)/);
+});

--- a/webui/tests/native-shared-components.test.ts
+++ b/webui/tests/native-shared-components.test.ts
@@ -32,6 +32,8 @@ test('shared components use native Vuetify cards, chips, timeline items, icons, 
   assert.match(headerSource, /<v-btn\b[^>]*icon="mdi-theme-light-dark"/);
   assert.match(timelineSource, /<v-timeline\b/);
   assert.match(timelineSource, /<v-timeline-item\b/);
+  assert.match(timelineSource, /function activityKey\(entry: ActivityEntry\)/);
+  assert.match(timelineSource, /:key="activityKey\(entry\)"/);
   assert.match(timelineSource, /#opposite/);
   assert.match(timelineSource, /#icon/);
   assert.match(timelineSource, /#default/);

--- a/webui/tests/pixiv-token-switch-layout.test.ts
+++ b/webui/tests/pixiv-token-switch-layout.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const pixivTokensView = readFileSync(
+  new URL('../src/views/PixivTokensView.vue', import.meta.url),
+  'utf8',
+);
+
+test('Pixiv token enabled switches are compact and left-aligned in native table cells', () => {
+  assert.match(
+    pixivTokensView,
+    /<template #item\.enabled="\{ item \}">\s*<div class="d-flex align-center justify-start w-100">\s*<VSwitch\s+:model-value="item\.enabled"\s+color="primary"\s+hide-details\s+density="compact"/s,
+  );
+});
+
+test('Pixiv token status, enabled, and action cells share left-aligned content', () => {
+  assert.match(
+    pixivTokensView,
+    /<template #item\.status="\{ item \}">[\s\S]*?<div class="d-flex align-center justify-start w-100">\s*<VChip\b/s,
+  );
+  assert.match(
+    pixivTokensView,
+    /<template #item\.actions="\{ item \}">[\s\S]*?<div class="d-flex align-center justify-start w-100 ga-1">\s*<VBtn\b/s,
+  );
+  assert.match(pixivTokensView, /<VBtn\b[^>]*aria-label="修改"/);
+  assert.match(pixivTokensView, /<VBtn\b[^>]*aria-label="删除"/);
+});
+
+test('Refresh Token content uses Vuetify vertical alignment and accessible icon buttons', () => {
+  assert.match(
+    pixivTokensView,
+    /<template #item\.token="\{ item \}">\s*<div class="d-flex align-center ga-2">/s,
+  );
+  assert.match(pixivTokensView, /<VBtn\b[\s\S]*?:aria-label="showFull\[item\.id\]/);
+  assert.doesNotMatch(pixivTokensView, /<Column\b|<InputSwitch\b|<Tag\b/);
+});

--- a/webui/tests/stat-card-icons.test.ts
+++ b/webui/tests/stat-card-icons.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const statCardSource = readFileSync(
+  new URL('../src/components/StatCard.vue', import.meta.url),
+  'utf8',
+);
+
+test('StatCard renders icons through native VIcon props', () => {
+  assert.match(statCardSource, /<v-icon\b/);
+  assert.match(statCardSource, /:icon="icon"/);
+  assert.doesNotMatch(statCardSource, /class=.*\bmdi\b/);
+  assert.doesNotMatch(statCardSource, /<i\b/);
+});

--- a/webui/tests/token-code-style.test.ts
+++ b/webui/tests/token-code-style.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const styles = readFileSync(new URL('../src/styles/main.css', import.meta.url), 'utf8');
+
+test('token code blocks use theme-aware color-mix backgrounds and readable text', () => {
+  assert.match(
+    styles,
+    /\.token-code\s*\{[^}]*background-color:\s*color-mix\(in srgb, rgb\(var\(--v-theme-primary\)\) 20%, transparent\)[^}]*color:\s*rgb\(var\(--v-theme-on-surface\)\)/s,
+  );
+  assert.match(
+    styles,
+    /\.token-code\s*\{[^}]*border:\s*1px solid color-mix\(in srgb, rgb\(var\(--v-theme-primary\)\) 35%, transparent\)/s,
+  );
+  assert.doesNotMatch(styles, /rgba\(var\(--v-theme-/);
+});

--- a/webui/tests/typescript-6-config.test.ts
+++ b/webui/tests/typescript-6-config.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const packageJson = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as { scripts: Record<string, string> };
+const tsconfig = JSON.parse(
+  readFileSync(new URL('../tsconfig.json', import.meta.url), 'utf8'),
+) as { compilerOptions: Record<string, unknown> };
+const nodeTsconfig = JSON.parse(
+  readFileSync(new URL('../tsconfig.node.json', import.meta.url), 'utf8'),
+) as { compilerOptions: Record<string, unknown> };
+
+test('TypeScript 6 uses Vite-compatible module resolution without deprecated baseUrl', () => {
+  assert.equal(tsconfig.compilerOptions.moduleResolution, 'Bundler');
+  assert.equal(tsconfig.compilerOptions.baseUrl, undefined);
+  assert.equal(nodeTsconfig.compilerOptions.moduleResolution, 'Bundler');
+  assert.match(packageJson.scripts.typecheck, /--skipLibCheck/);
+});

--- a/webui/tsconfig.json
+++ b/webui/tsconfig.json
@@ -3,14 +3,14 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "strict": true,
+    "skipLibCheck": true,
     "jsx": "preserve",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "esModuleInterop": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/webui/tsconfig.node.json
+++ b/webui/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]

--- a/webui/tsconfig.tests.json
+++ b/webui/tsconfig.tests.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue",
+    "tests/**/*.ts"
+  ]
+}

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -2,10 +2,11 @@ import { fileURLToPath, URL } from 'node:url';
 
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
+import vuetify from 'vite-plugin-vuetify';
 
 export default defineConfig({
   base: '/admin/',
-  plugins: [vue()],
+  plugins: [vue(), vuetify({ autoImport: true })],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))


### PR DESCRIPTION
## Summary
- Migrate the admin WebUI from PrimeVue compatibility components to native Vuetify components.
- Align backend API pagination, error contracts, frontend startup behavior, and logging configuration.
- Restore desktop navigation drawer visibility and add regression coverage for the WebUI and API contracts.

## Verification
- `.venv\Scripts\python.exe -m pytest -q`
- `cd webui && npm test`
- `cd webui && npm run test:typecheck`
- `cd webui && npm run typecheck`
- `cd webui && npm run build`